### PR TITLE
Reduce border clutter on the parameters screen

### DIFF
--- a/src/renderer/pages/Parameters/Parameters.tsx
+++ b/src/renderer/pages/Parameters/Parameters.tsx
@@ -123,7 +123,7 @@ export default function ParametersPage({ instance, refreshInstancesList, logMess
   };
 
   return (
-    <Paper variant="outlined" sx={{ p: 2, height: '100%', boxSizing: 'border-box' }}>
+    <Box >
       <Typography variant="h6">
         [{instance.name}] {instance.workflow_version.name}
       </Typography>
@@ -150,6 +150,6 @@ export default function ParametersPage({ instance, refreshInstancesList, logMess
           {t('parameters.launch-workflow')}
         </Button>
       </Stack>
-    </Paper>
+    </Box>
   );
 }


### PR DESCRIPTION
Resoves #39 

Before:
<img width="500" alt="Screenshot 2025-11-19 at 09 26 55" src="https://github.com/user-attachments/assets/eecd5fca-beaf-48bd-bdc3-0a0266fc1294" />

After:
<img width="500" alt="Screenshot 2025-11-19 at 09 27 19" src="https://github.com/user-attachments/assets/a999f339-13f4-4593-b002-341902a46d79" />
