### PR TITLE
Display exit status in Instances list

### DIFF
--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -72,7 +72,7 @@
       "running": "Running",
       "completed": "Completed",
       "unknown": "Unknown",
-      "aborted": "Aborted"
+      "failed": "Failed"
     },
     "open-results-folder": "Open Results Folder"
   },

--- a/src/locales/fr/translation.json
+++ b/src/locales/fr/translation.json
@@ -72,7 +72,7 @@
       "running": "En cours",
       "completed": "Terminé",
       "unknown": "Inconnu",
-      "aborted": "Annulé"
+      "failed": "Échoué"
     },
     "open-results-folder": "Ouvrir le dossier des résultats"
   },

--- a/src/renderer/pages/Monitor/ProgressTracker.tsx
+++ b/src/renderer/pages/Monitor/ProgressTracker.tsx
@@ -9,6 +9,7 @@ import CancelIcon from '@mui/icons-material/Cancel';
 import RefreshIcon from '@mui/icons-material/Refresh';
 import AnsiLog from './AnsiLog.js';
 import { API } from '../../services/api.js';
+import { WorkflowStatus } from '../../../types/types.js';
 import { useTranslation } from 'react-i18next';
 import FolderOutlinedIcon from '@mui/icons-material/FolderOutlined';
 import DescriptionIcon from '@mui/icons-material/Description';
@@ -56,10 +57,9 @@ export default function ProgressTracker({ instance, nextflowProgress, workflowSt
 
   const FormatWorkflowStatus = ({ workflowStatus: string }) => {
     let color_palette = 'info';
-    console.log('workflowStatus', workflowStatus);
-    if (workflowStatus === 'aborted') {
+    if (workflowStatus === WorkflowStatus.Failed) {
       color_palette = 'error';
-    } else if (workflowStatus === 'completed') {
+    } else if (workflowStatus === WorkflowStatus.Completed) {
       color_palette = 'success';
     }
     return (

--- a/src/renderer/pages/Parameters/Parameters.tsx
+++ b/src/renderer/pages/Parameters/Parameters.tsx
@@ -123,7 +123,7 @@ export default function ParametersPage({ instance, refreshInstancesList, logMess
   };
 
   return (
-    <Box >
+    <Box>
       <Typography variant="h6">
         [{instance.name}] {instance.workflow_version.name}
       </Typography>

--- a/src/runners/nextflow/nf-parse.ts
+++ b/src/runners/nextflow/nf-parse.ts
@@ -1,5 +1,6 @@
 import * as fs from 'fs';
 import * as readline from 'readline';
+import { WorkflowStatus } from '../../types/types.js';
 
 const file = process.argv[2] ?? '.nextflow.log';
 
@@ -111,10 +112,10 @@ export async function readNextflowLog(path: string) {
           });
           break;
         case 'aborted':
-          progress['workflow'].push({ time: ts, status: 'aborted', cause: m[1] });
+          progress['workflow'].push({ time: ts, status: WorkflowStatus.Failed, cause: m[1] });
           break;
         case 'wf_done':
-          progress['workflow'].push({ time: ts, status: 'completed' });
+          progress['workflow'].push({ time: ts, status: WorkflowStatus.Completed });
           break;
       }
       break; // one event per line is enough

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -3,5 +3,6 @@ export enum WorkflowStatus {
   Running = 'running',
   Completed = 'completed',
   Closed = 'closed',
-  Failed = 'failed'
+  Failed = 'failed',
+  Unknown = 'unknown'
 }


### PR DESCRIPTION
Exit status is now displayed in instances list (instead of simply marking completed jobs as 'completed' with a green tick):
<img width="1143" height="363" alt="Screenshot 2025-11-19 at 13 16 25" src="https://github.com/user-attachments/assets/72a26e19-5215-4e96-9d94-9031829acc29" />

Resolves #11 