### PR TITLE
Add Windows CI tests

### DIFF
--- a/.github/workflows/GLACIER.yml
+++ b/.github/workflows/GLACIER.yml
@@ -20,3 +20,5 @@ jobs:
     uses: ./.github/workflows/unit.yml
   e2e-tests:
     uses: ./.github/workflows/e2e.yml
+  e2e-tests-win:
+    uses: ./.github/workflows/e2e_wsl.yml

--- a/.github/workflows/e2e_wsl.yml
+++ b/.github/workflows/e2e_wsl.yml
@@ -1,0 +1,50 @@
+name: End-to-end tests (Windows WSL)
+
+on:
+  workflow_call:
+  workflow_dispatch:
+
+jobs:
+  e2e-tests-win:
+    runs-on: windows-latest
+    timeout-minutes: 45
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: lts/*
+          cache: 'npm'
+
+      - name: Enable WSL
+        run: |
+          wsl --install -d Ubuntu --no-launch
+          wsl -l -v
+          wsl --set-default Ubuntu
+      - name: Install dependencies inside WSL
+        run: |
+          wsl bash -lc "sudo apt-get update"
+          wsl bash -lc "sudo apt-get install -y openjdk-17-jre curl unzip"
+      - name: Install Nextflow inside WSL
+        run: |
+          wsl bash -lc "curl -s https://get.nextflow.io | bash"
+          wsl bash -lc "sudo mv nextflow /usr/local/bin/"
+
+      - name: Install dependencies
+        run: npm ci
+      - name: Install Playwright Browsers
+        run: npx playwright install --with-deps
+      - name: Platform specific CI setup
+        run: ./tests/e2e/ci-setup.sh
+      - name: Build GLACIER
+        run: npm run build
+      - name: Run Playwright tests
+        run: npx playwright test
+      - uses: actions/upload-artifact@v4
+        if: ${{ !cancelled() }}
+        with:
+          name: playwright-report-${{ matrix.os }}
+          path: |
+            playwright-report/
+            test-results/
+          retention-days: 7


### PR DESCRIPTION
Add Windows CI testing, which includes WSL download, setup and end-to-end tests on the github runners. GLACIER runs in Windows but uses WSL to launch nextflow pipelines. The e2e tests include launch and validation that the pipeline has run successfully (which requires WSL/nextflow on Windows platform).

Due to the setup costs this workflow can take ~15 mins to run.