### PR TITLE
Allow user to select repository tag to download

### DIFF
--- a/api-server/index.js
+++ b/api-server/index.js
@@ -82,7 +82,7 @@ app.post('/api/get-available-profiles', async (req, res) =>
 );
 
 app.post('/api/clone-repo', async (req, res) =>
-  post_response(res, collection.cloneRepo(req.body.repoRef))
+  post_response(res, collection.cloneRepo(req.body.repoUrl, req.body.ver))
 );
 
 app.post('/api/sync-repo', async (req, res) =>
@@ -119,6 +119,26 @@ app.post('/api/get-workflow-params', async (req, res) =>
 
 app.post('/api/get-workflow-schema', async (req, res) =>
   post_response(res, collection.getWorkflowSchema(req.body.repoPath))
+);
+
+app.post('/api/get-projects-list', async (req, res) =>
+  post_response(res, collection.getProjectsList())
+);
+
+app.post('/api/add-project', async (req, res) =>
+  post_response(res, collection.addProject(req.body.repoPath))
+);
+
+app.post('/api/remove-project', async (req, res) =>
+  post_response(res, collection.removeProject(req.body.project))
+);
+
+app.post('/api/get-installable-repos-list', async (req, res) =>
+  post_response(res, collection.getInstallableReposList())
+);
+
+app.post('/api/add-installable-repo', async (req, res) =>
+  post_response(res, collection.addInstallableRepo(req.body.repoUrl))
 );
 
 const PORT = process.env.PORT || 3030;

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -8,12 +8,15 @@
     "settings": "Settings"
   },
   "hub": {
-    "clone-a-github-repository": "Clone a GitHub repository",
+    "add-workflow-from-repository": "Add Workflow from Repository",
     "repo": "Repo",
+    "add": "Add",
     "clone": "Clone",
     "clone-return-none": "Clone failed or returned nothing",
     "clone-failed": "Clone operation failed",
-    "install": "Install"
+    "install": "Install",
+    "repo-added": "Repository added successfully",
+    "repo-add-failed": "Failed to add repository"
   },
   "library": {
     "local-repositories": "Local Repositories",

--- a/src/locales/fr/translation.json
+++ b/src/locales/fr/translation.json
@@ -8,12 +8,15 @@
     "settings": "Paramètres"
   },
   "hub": {
-    "clone-a-github-repository": "Cloner un dépôt GitHub",
+    "add-workflow-from-repository": "Ajouter un flux de travail depuis un dépôt",
     "repo": "Dépôt",
+    "add": "Ajouter",
     "clone": "Cloner",
     "clone-return-none": "Le clonage a échoué ou n'a rien retourné",
     "clone-failed": "L'opération de clonage a échoué",
-    "install": "Installer"
+    "install": "Installer",
+    "repo-added": "Dépôt ajouté avec succès",
+    "repo-add-failed": "L'ajout du dépôt a échoué"
   },
   "library": {
     "local-repositories": "Dépôts locaux",

--- a/src/main/ipc-handlers.ts
+++ b/src/main/ipc-handlers.ts
@@ -8,9 +8,12 @@ import { Collection } from './collection.js';
 const collection = Collection.getInstance();
 
 export function registerIpcHandlers() {
-  ipcMain.handle('create-workflow-instance', async (event, workflow_id: string) => {
-    return collection.createWorkflowInstance(workflow_id);
-  });
+  ipcMain.handle(
+    'create-workflow-instance',
+    async (event, workflow_id: string, version: string) => {
+      return collection.createWorkflowInstance(workflow_id, version);
+    }
+  );
 
   ipcMain.handle('list-workflow-instances', async () => {
     return collection.listWorkflowInstances();
@@ -64,8 +67,8 @@ export function registerIpcHandlers() {
     return collection.getAvailableProfiles(instance);
   });
 
-  ipcMain.handle('clone-repo', async (event, repoUrl) => {
-    return await collection.cloneRepo(repoUrl);
+  ipcMain.handle('clone-repo', async (event, repoUrl, ver) => {
+    return await collection.cloneRepo(repoUrl, ver);
   });
 
   ipcMain.handle('get-collections-path', () => {
@@ -106,5 +109,13 @@ export function registerIpcHandlers() {
 
   ipcMain.handle('remove-project', async (event, project) => {
     return collection.removeProject(project);
+  });
+
+  ipcMain.handle('get-installable-repos-list', async (event) => {
+    return collection.getInstallableReposList();
+  });
+
+  ipcMain.handle('add-installable-repo', async (event, repoUrl) => {
+    return collection.addInstallableRepo(repoUrl);
   });
 }

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -1,8 +1,8 @@
 const { contextBridge, ipcRenderer } = require('electron'); // must be CommonJS for electron
 
 contextBridge.exposeInMainWorld('electronAPI', {
-  createWorkflowInstance: (workflow_id: string) =>
-    ipcRenderer.invoke('create-workflow-instance', workflow_id),
+  createWorkflowInstance: (workflow_id: string, version: string) =>
+    ipcRenderer.invoke('create-workflow-instance', workflow_id, version),
   runWorkflow: (instance: any, params: any, opts: any) =>
     ipcRenderer.invoke('run-workflow', instance, params, opts),
   listWorkflowInstances: () => ipcRenderer.invoke('list-workflow-instances'),
@@ -27,7 +27,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
     ipcRenderer.invoke('get-work-log', instance, workID, logType),
   getAvailableProfiles: (instance: any) => ipcRenderer.invoke('get-available-profiles', instance),
 
-  cloneRepo: (repoUrl: string) => ipcRenderer.invoke('clone-repo', repoUrl),
+  cloneRepo: (repoUrl: string, ver: string) => ipcRenderer.invoke('clone-repo', repoUrl, ver),
   getCollectionsPath: () => ipcRenderer.invoke('get-collections-path'),
   setCollectionsPath: (path: string) => ipcRenderer.invoke('set-collections-path', path),
   getCollections: () => ipcRenderer.invoke('get-collections'),
@@ -38,5 +38,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
   getWorkflowSchema: (repoPath: string) => ipcRenderer.invoke('get-workflow-schema', repoPath),
   getProjectsList: () => ipcRenderer.invoke('get-projects-list'),
   addProject: (repoPath: string) => ipcRenderer.invoke('add-project', repoPath),
-  removeProject: (project: any) => ipcRenderer.invoke('remove-project', project)
+  removeProject: (project: any) => ipcRenderer.invoke('remove-project', project),
+  getInstallableReposList: () => ipcRenderer.invoke('get-installable-repos-list'),
+  addInstallableRepo: (repoUrl: string) => ipcRenderer.invoke('add-installable-repo', repoUrl)
 });

--- a/src/main/types.ts
+++ b/src/main/types.ts
@@ -6,3 +6,7 @@ export interface IRepo {
   version: string;
   params?: { [key: string]: string };
 }
+
+export interface IRepoVersions extends IRepo {
+  versions: string[];
+}

--- a/src/renderer/pages/Library.tsx
+++ b/src/renderer/pages/Library.tsx
@@ -8,7 +8,9 @@ import {
   Typography,
   Box,
   Grid,
+  Select,
   Snackbar,
+  MenuItem,
   Alert
 } from '@mui/material';
 import { useTranslation } from 'react-i18next';
@@ -37,6 +39,20 @@ export default function LibraryPage({
     })();
   }, []);
 
+  const onClickSync = async (repo) => {
+    try {
+      const result = await API.syncRepo(repo.path);
+      if (result?.status === 'ok') {
+        logMessage(t('library.repo-sync-success'), 'success');
+      } else {
+        throw new Error(result?.message || t('library.repo-sync-failed'));
+      }
+    } catch (err) {
+      console.error(err);
+      logMessage(t('library.repo-sync-failed'), 'error');
+    }
+  };
+
   return (
     <Container sx={{ pb: 12 }}>
       {' '}
@@ -48,7 +64,7 @@ export default function LibraryPage({
             <Grid item xs={12} sm={6} md={4} key={repo.path}>
               <Paper variant="outlined" sx={{ p: 2 }}>
                 <Typography variant="subtitle1" gutterBottom>
-                  {repo.name}
+                  {repo.name} ({repo.version})
                 </Typography>
                 <Stack direction="row" spacing={1}>
                   <Button
@@ -63,19 +79,7 @@ export default function LibraryPage({
                     id={`collections-sync-${repo.name}`}
                     size="small"
                     variant="outlined"
-                    onClick={async () => {
-                      try {
-                        const result = await API.syncRepo(repo.path);
-                        if (result?.status === 'ok') {
-                          logMessage(t('library.repo-sync-success'), 'success');
-                        } else {
-                          throw new Error(result?.message || t('library.repo-sync-failed'));
-                        }
-                      } catch (err) {
-                        console.error(err);
-                        logMessage(t('library.repo-sync-failed'), 'error');
-                      }
-                    }}
+                    onClick={() => onClickSync(repo)}
                   >
                     {t('library.sync')}
                   </Button>

--- a/src/renderer/pages/Main.tsx
+++ b/src/renderer/pages/Main.tsx
@@ -144,7 +144,7 @@ export default function MainPage({ darkMode, setDarkMode }) {
 
   const addToInstancesList = async (repo) => {
     const workflow_id = repo.id;
-    API.createWorkflowInstance(workflow_id).then((instance) => {
+    API.createWorkflowInstance(workflow_id, repo.version).then((instance) => {
       setInstancesList((prev) => {
         const newQueue = [...prev, { instance: instance, name: instance.name }];
         setView('instances');

--- a/src/renderer/pages/Monitor/HeaderMenu.tsx
+++ b/src/renderer/pages/Monitor/HeaderMenu.tsx
@@ -151,10 +151,10 @@ export default function HeaderMenu({ instance, logMessage }) {
         }}
       >
         <Typography variant="h6" sx={{ textAlign: 'center' }}>
-          {instance['name']}
+          {instance.name}
         </Typography>
         <Typography variant="subtitle1" sx={{ textAlign: 'center' }}>
-          {instance['workflow_version']['name']}
+          {instance.workflow_version.name}
         </Typography>
       </Box>
 

--- a/src/renderer/pages/Parameters/Parameters.tsx
+++ b/src/renderer/pages/Parameters/Parameters.tsx
@@ -124,9 +124,18 @@ export default function ParametersPage({ instance, refreshInstancesList, logMess
 
   return (
     <Box>
-      <Typography variant="h6">
-        [{instance.name}] {instance.workflow_version.name}
-      </Typography>
+      <Box display="flex" justifyContent="space-between" alignItems="center">
+        <Typography variant="h6">
+          [{instance.name}] {instance.workflow_version.name}
+        </Typography>
+        <Button
+          disabled={schemaErrors !== null}
+          variant="contained"
+          onClick={() => onLaunch(instance, params)}
+        >
+          {t('parameters.launch-workflow')}
+        </Button>
+      </Box>
       <Stack spacing={2} sx={{ mt: 1 }}>
         <Paper variant="outlined" sx={{ p: 2, mb: 2 }}>
           {!isEmpty(schema) ? (
@@ -142,13 +151,6 @@ export default function ParametersPage({ instance, refreshInstancesList, logMess
             <Typography>No parameters.</Typography>
           )}
         </Paper>
-        <Button
-          disabled={schemaErrors !== null}
-          variant="contained"
-          onClick={() => onLaunch(instance, params)}
-        >
-          {t('parameters.launch-workflow')}
-        </Button>
       </Stack>
     </Box>
   );

--- a/src/renderer/pages/Parameters/VerticalCategorizationRenderer.jsx
+++ b/src/renderer/pages/Parameters/VerticalCategorizationRenderer.jsx
@@ -60,7 +60,7 @@ const VerticalCategorization = ({ uischema, schema, path, visible }) => {
 
       <Box sx={{ flex: 1, p: 2, minWidth: 0 }}>
         {categories.map((cat, i) => (
-          <div
+          <Box
             role="tabpanel"
             hidden={value !== i}
             id={`vert-tabpanel-${i}`}
@@ -82,7 +82,7 @@ const VerticalCategorization = ({ uischema, schema, path, visible }) => {
                 )}
               </>
             )}
-          </div>
+          </Box>
         ))}
       </Box>
     </Box>

--- a/src/renderer/services/api.ts
+++ b/src/renderer/services/api.ts
@@ -2,8 +2,8 @@ const isElectron = Boolean(window?.electronAPI);
 
 const electronAPI = isElectron
   ? {
-      createWorkflowInstance: (workflow_id) =>
-        window.electronAPI.createWorkflowInstance(workflow_id),
+      createWorkflowInstance: (workflow_id, version) =>
+        window.electronAPI.createWorkflowInstance(workflow_id, version),
       runWorkflow: (instance, params, opts) =>
         window.electronAPI.runWorkflow(instance, params, opts),
       listWorkflowInstances: () => window.electronAPI.listWorkflowInstances(),
@@ -26,7 +26,7 @@ const electronAPI = isElectron
         window.electronAPI.getWorkLog(instance, workID, logType),
       getAvailableProfiles: (instance) => window.electronAPI.getAvailableProfiles(instance),
 
-      cloneRepo: (repoRef) => window.electronAPI.cloneRepo(repoRef),
+      cloneRepo: (repoUrl, ver) => window.electronAPI.cloneRepo(repoUrl, ver),
       syncRepo: (repo) => window.electronAPI.syncRepo(repo),
       getCollections: () => window.electronAPI.getCollections(),
       getCollectionsPath: () => window.electronAPI.getCollectionsPath(),
@@ -38,7 +38,9 @@ const electronAPI = isElectron
       getWorkflowSchema: (repoPath) => window.electronAPI.getWorkflowSchema(repoPath),
       getProjectsList: () => window.electronAPI.getProjectsList(),
       addProject: (repoPath) => window.electronAPI.addProject(repoPath),
-      removeProject: (project) => window.electronAPI.removeProject(project)
+      removeProject: (project) => window.electronAPI.removeProject(project),
+      getInstallableReposList: () => window.electronAPI.getInstallableReposList(),
+      addInstallableRepo: (repoUrl) => window.electronAPI.addInstallableRepo(repoUrl)
     }
   : null;
 
@@ -54,8 +56,8 @@ const httpDispatch = async (endpoint, method = 'GET', body = null) => {
 };
 
 const httpAPI = {
-  createWorkflowInstance: async (workflow_id) =>
-    httpDispatch('/api/create-workflow-instance', 'POST', { workflow_id }),
+  createWorkflowInstance: async (workflow_id, version) =>
+    httpDispatch('/api/create-workflow-instance', 'POST', { workflow_id, version }),
   runWorkflow: async (instance, params, opts) =>
     httpDispatch('/api/run-workflow', 'POST', { instance, params, opts }),
   listWorkflowInstances: async () => httpDispatch('/api/list-workflow-instances', 'POST', {}),
@@ -85,7 +87,7 @@ const httpAPI = {
     httpDispatch('/api/get-work-log', 'POST', { instance, workID, logType }),
   getAvailableProfiles: async (instance) =>
     httpDispatch('/api/get-available-profiles', 'POST', { instance }),
-  cloneRepo: async (repoRef) => httpDispatch('/api/clone-repo', 'POST', { repoRef }),
+  cloneRepo: async (repoUrl, ver) => httpDispatch('/api/clone-repo', 'POST', { repoUrl, ver }),
   syncRepo: async (repo) => httpDispatch('/api/sync-repo', 'POST', { repo }),
   getCollections: async () => httpDispatch('/api/get-collections', 'POST', {}),
   getCollectionsPath: async () => httpDispatch('/api/get-collections-path', 'POST', {}),
@@ -101,7 +103,10 @@ const httpAPI = {
     httpDispatch('/api/get-workflow-schema', 'POST', { repoPath }),
   getProjectsList: async () => httpDispatch('/api/get-projects-list', 'POST', {}),
   addProject: async (repoPath) => httpDispatch('/api/add-project', 'POST', { repoPath }),
-  removeProject: async (project) => httpDispatch('/api/remove-project', 'POST', { project })
+  removeProject: async (project) => httpDispatch('/api/remove-project', 'POST', { project }),
+  getInstallableReposList: async () => httpDispatch('/api/get-installable-repos-list', 'POST', {}),
+  addInstallableRepo: async (repoUrl) =>
+    httpDispatch('/api/add-installable-repo', 'POST', { repoUrl })
 };
 
 export const API = isElectron ? electronAPI : httpAPI;

--- a/src/runners/nextflow/nextflow.ts
+++ b/src/runners/nextflow/nextflow.ts
@@ -17,16 +17,16 @@ const is_windows = process.platform === 'win32';
 
 const toPosixPath = (base: string) => {
   return slash(base).replace('C:', '/mnt/c');
-}
+};
 
 const resolvePath = (base: string, name: string) => {
-  const rtn = toPosixPath(path.resolve(base, name))
+  const rtn = toPosixPath(path.resolve(base, name));
   return rtn;
-}
+};
 
 const looksLikePath = (s: string): boolean => {
   return /^[a-zA-Z]:\\/.test(s) || /[\\/]/.test(s);
-}
+};
 
 const paramsToPosix = (params: any): any => {
   if (Array.isArray(params)) {
@@ -43,7 +43,7 @@ const paramsToPosix = (params: any): any => {
     return params;
   }
   return params;
-}
+};
 
 export async function runWorkflow(
   instance: IWorkflowInstance,
@@ -52,7 +52,7 @@ export async function runWorkflow(
 ) {
   // Launch nextflow natively on host system
   const name = instance.name;
-  const instancePath = instance.path;  // launch from Windows path (on win32)
+  const instancePath = instance.path; // launch from Windows path (on win32)
   const workPath = resolvePath(instancePath, 'work');
   await fs.mkdir(workPath, { recursive: true });
   const projectPath = instance.workflow_version?.path || instancePath;
@@ -102,24 +102,22 @@ export async function runWorkflow(
 
     const bashArgs = [
       cmd,
-      '>', resolvePath(instancePath, 'stdout.log'),
-      '2>', resolvePath(instancePath, 'stderr.log'),
+      '>',
+      resolvePath(instancePath, 'stdout.log'),
+      '2>',
+      resolvePath(instancePath, 'stderr.log'),
       '<',
-      '/dev/null',
+      '/dev/null'
     ];
     const bashCmd = bashArgs.join(' ');
 
     console.log(`Spawning nextflow with command: ${cmd} from ${instancePath}`);
-    const p = spawn(
-      'wsl.exe',
-      ['-e', 'bash', '-lc', bashCmd],
-      {
-        cwd: instancePath,
-        stdio: ['ignore', 'pipe', 'pipe'],
-        windowsHide: true,
-        detached: true,
-      }
-    );
+    const p = spawn('wsl.exe', ['-e', 'bash', '-lc', bashCmd], {
+      cwd: instancePath,
+      stdio: ['ignore', 'pipe', 'pipe'],
+      windowsHide: true,
+      detached: true
+    });
     p.unref();
 
     return p.pid;

--- a/tests/e2e/ui.spec.ts
+++ b/tests/e2e/ui.spec.ts
@@ -54,12 +54,17 @@ test('clone a repository', async ({ page }) => {
   // --- Navigate to Hub page
   await page.click('#sidebar-hub-button');
 
-  // Clone repository
+  // Add repository
   const repo_owner = 'jsbrittain';
   const repo_name = 'workflow-runner-test-nextflow';
   await page.fill('#collections-repo-url', `${repo_owner}/${repo_name}`);
-  await page.click('#collections-clone-button');
-  await waitForLogLine(page, new RegExp(`^Cloned main to `));
+  await page.click('#collections-add-button');
+  await page.waitForSelector('#hub-install-workflow-runner-test-nextflow', {
+    timeout: TIMEOUT_10s
+  });
+
+  // Clone the new repository
+  await page.click('#hub-install-workflow-runner-test-nextflow');
 
   // --- Navigate to Library page
   await page.click('#sidebar-library-button');


### PR DESCRIPTION
- Permit user to select tag for repository cloning
- Change 'Clone' (for arbitrary repositories) to 'Add', which places the repo in the Hub for installation
- Support multiple workflow 'versions' simultaneously (resolve some minor bugs)
- Move default workflows list to backend
- Bring API-Server interface in-line with electron IPC handlers
- Add 'loading' spinner when cloning workflow