### PR TITLE
Beautify file and folder selection with IconButton

### DIFF
--- a/src/renderer/pages/Parameters/FilePathControl.tsx
+++ b/src/renderer/pages/Parameters/FilePathControl.tsx
@@ -2,7 +2,10 @@
 import React from 'react';
 import { withJsonFormsControlProps } from '@jsonforms/react';
 import { ControlProps, isDescriptionHidden } from '@jsonforms/core';
-import { TextField, Button, Stack } from '@mui/material';
+import { TextField, IconButton, Stack } from '@mui/material';
+import { Box } from '@mui/system';
+import FileOpenIcon from '@mui/icons-material/FileOpen';
+import FolderOpenIcon from '@mui/icons-material/FolderOpen';
 
 const toFilters = (accept?: string): Electron.FileFilter[] | undefined => {
   // accept like ".csv,.fastq,.fastq.gz,application/json"
@@ -56,21 +59,34 @@ function InnerFilePathControl(props: ControlProps) {
   };
 
   return (
-    <Stack spacing={1} sx={{ opacity: enabled ? 1 : 0.6 }}>
-      <TextField
-        id={id}
-        label={label}
-        value={data ?? ''}
-        required={required}
-        InputProps={{ readOnly: true }}
-        disabled={!enabled}
-        error={Boolean(errors)}
-        helperText={errors || (showDesc ? description : undefined)}
-        size="small"
-      />
-      <Button variant="outlined" size="small" onClick={pick} disabled={!enabled}>
-        {isDirectory ? 'Choose folder…' : 'Choose file…'}
-      </Button>
+    <Stack
+      direction="row"
+      spacing={1}
+      sx={{ opacity: enabled ? 1 : 0.6 }}
+      alignItems="flex-start" // top-align the children
+    >
+      {/* Left: field + helper text */}
+      <Box sx={{ flexGrow: 1 }}>
+        <TextField
+          id={id}
+          label={label}
+          value={data ?? ''}
+          required={required}
+          InputProps={{ readOnly: true }}
+          disabled={!enabled}
+          error={Boolean(errors)}
+          helperText={errors || (showDesc ? description : undefined)}
+          size="small"
+          fullWidth
+        />
+      </Box>
+
+      {/* Right: icon, top-aligned with the field */}
+      <Box sx={{ display: 'flex', alignItems: 'flex-start' }}>
+        <IconButton onClick={pick} disabled={!enabled}>
+          {isDirectory ? <FolderOpenIcon /> : <FileOpenIcon />}
+        </IconButton>
+      </Box>
     </Stack>
   );
 }


### PR DESCRIPTION

Replace existing file and folder select text buttons...
<img width="500" alt="515119110-6f173723-ac06-4b53-ad2b-92504db9cae1" src="https://github.com/user-attachments/assets/ca3e510d-9dfe-4a05-9cbd-f4927676b280" />

... with the offical mui fileOpen and folderOpen (in-line) icon buttons:
<img width="500" alt="Screenshot 2025-11-27 at 16 34 00" src="https://github.com/user-attachments/assets/e402d0d9-d7f8-4942-859a-9114ca2de6b5" />
<img width="500" alt="Screenshot 2025-11-27 at 16 33 53" src="https://github.com/user-attachments/assets/40ca6acb-f22d-4005-88a3-70903a3139f9" />
