### PR TITLE
Disable uppercasing of parameter categories

### DIFF
--- a/src/renderer/pages/Parameters/VerticalCategorizationRenderer.jsx
+++ b/src/renderer/pages/Parameters/VerticalCategorizationRenderer.jsx
@@ -54,6 +54,7 @@ const VerticalCategorization = ({ uischema, schema, path, visible }) => {
             label={getLabel(cat, i)}
             id={`vert-tab-${i}`}
             aria-controls={`vert-tabpanel-${i}`}
+            sx={{ textTransform: 'none' }}
           />
         ))}
       </Tabs>


### PR DESCRIPTION
Disabling Uppercasing of parameter categories:
<img width="500" alt="Screenshot 2025-11-27 at 17 16 22" src="https://github.com/user-attachments/assets/d9c57fb2-c991-4cbe-970a-8e8a978f87e8" />
