### PR TITLE
Allow selection of multiple profiles during workflow launch

### DIFF
--- a/src/renderer/pages/Parameters/Parameters.tsx
+++ b/src/renderer/pages/Parameters/Parameters.tsx
@@ -89,11 +89,19 @@ export default function ParametersPage({ instance, refreshInstancesList, logMess
           schema['properties'] = {};
         }
         schema['properties']['profile'] = {
-          type: 'string',
-          title: 'Execution Profile',
-          description: 'Select the execution profile to use',
-          enum: profiles,
-          default: profiles.includes(default_profile) ? default_profile : profiles[0]
+          type: 'array',
+          title: 'Execution Profile(s)',
+          description: 'Select one or more execution profile to use',
+          items: {
+            type: 'string',
+            enum: profiles
+          },
+          uniqueItems: true,
+          default: profiles.includes(default_profile)
+            ? [default_profile]
+            : profiles.length > 0
+              ? [profiles[0]]
+              : []
         };
       }
       setSchema(schema);


### PR DESCRIPTION
Allow selection of multiple profiles during workflow launch.

This PR also fixes a bug where nested containers in the nextflow.config file were identified as profiles (only top-level entries under the 'profiles' heading should be extracted).

Resolves #2 