### PR TITLE
Support Test profile launch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: Build & Release
 on:
   push:
     tags:
-      - "v*"
+      - 'v*'
 
 permissions:
   contents: write

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -1,6 +1,9 @@
 {
   "glacier": "GLACIER",
   "container-started": "Container built and started with ID",
+  "common": {
+    "cancel": "Cancel"
+  },
   "sidebar": {
     "hub": "Hub",
     "library": "Library",
@@ -48,8 +51,14 @@
       "title": "Description"
     },
     "params": {
-      "title": "Parameters"
-    }
+      "title": "Parameters",
+      "no-parameters": "No parameters available"
+    },
+    "test-launch-dropdown": "Test",
+    "test-launch-title": "Test Options",
+    "test-launch-instructions": "Select additional profiles to launch the test workflow with (default `docker` if present).",
+    "additional-test-profiles": "Additional Test Profiles",
+    "test-launch-workflow": "Run"
   },
   "monitor": {
     "logs": {

--- a/src/locales/fr/translation.json
+++ b/src/locales/fr/translation.json
@@ -1,6 +1,9 @@
 {
   "glacier": "GLACIER",
   "container-started": "Conteneur construit et démarré avec l'ID",
+  "common": {
+    "cancel": "Annuler"
+  },
   "sidebar": {
     "hub": "Hub",
     "library": "Bibliothèque",
@@ -48,8 +51,14 @@
       "title": "Description"
     },
     "params": {
-      "title": "Paramètres"
-    }
+      "title": "Paramètres",
+      "no-parameters": "Aucun paramètre requis pour ce flux de travail."
+    },
+    "test-launch-dropdown": "Test",
+    "test-launch-title": "Options de test",
+    "test-launch-instructions": "Sélectionnez des profils supplémentaires pour lancer le flux de travail de test (par défaut `docker` si présent).",
+    "additional-test-profiles": "Profils de test supplémentaires",
+    "test-launch-workflow": "Exécuter"
   },
   "monitor": {
     "logs": {

--- a/src/renderer/pages/Parameters/TestRunDialog.tsx
+++ b/src/renderer/pages/Parameters/TestRunDialog.tsx
@@ -1,0 +1,112 @@
+import React from 'react';
+import {
+  Button,
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  FormControl,
+  InputLabel,
+  Select,
+  MenuItem,
+  OutlinedInput,
+  Chip,
+  Box,
+  Typography
+} from '@mui/material';
+import { useTranslation } from 'react-i18next';
+
+export default function TestLaunchDialog({ allProfiles, onLaunch }) {
+  const { t } = useTranslation();
+  const [open, setOpen] = React.useState(false);
+  const [selected, setSelected] = React.useState<string[]>(
+    allProfiles.includes('docker') ? ['docker'] : []
+  );
+
+  const handleOpen = () => setOpen(true);
+  const handleClose = () => setOpen(false);
+
+  const handleChange = (event: React.ChangeEvent<{ value: unknown }>) => {
+    setSelected(event.target.value as string[]);
+  };
+
+  const handleLaunch = () => {
+    onLaunch(['test', ...selected]);
+    setOpen(false);
+  };
+
+  return (
+    <>
+      <Button variant="outlined" onClick={handleOpen}>
+        {t('parameters.test-launch-dropdown')}
+      </Button>
+
+      <Dialog
+        open={open}
+        onClose={handleClose}
+        fullWidth
+        maxWidth="sm"
+        aria-labelledby="test-launch-dialog-title"
+      >
+        <DialogTitle id="test-launch-dialog-title">{t('parameters.test-launch-title')}</DialogTitle>
+
+        <DialogContent dividers>
+          <Typography variant="body2" gutterBottom>
+            {t('parameters.test-launch-instructions') || ''}
+          </Typography>
+
+          <FormControl sx={{ mt: 1, width: '100%' }}>
+            <InputLabel id="parameters-additional-test-profiles-label">
+              {t('parameters.additional-test-profiles')}
+            </InputLabel>
+
+            <Select
+              labelId="parameters-additional-test-profiles-label"
+              id="parameters-additional-test-profiles"
+              multiple
+              value={selected}
+              onChange={handleChange}
+              input={
+                <OutlinedInput
+                  id="select-additional-test-profiles"
+                  label={t('parameters.additional-test-profiles')}
+                />
+              }
+              MenuProps={{
+                disablePortal: true,
+                PaperProps: {
+                  sx: {
+                    minWidth: '100%',
+                    maxHeight: 300
+                  }
+                }
+              }}
+              renderValue={(selectedValue) => (
+                <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.5 }}>
+                  {(selectedValue as string[]).map((value) => (
+                    <Chip key={value} label={value} />
+                  ))}
+                </Box>
+              )}
+            >
+              {allProfiles
+                .filter((name) => name !== 'test')
+                .map((name) => (
+                  <MenuItem key={name} value={name}>
+                    {name}
+                  </MenuItem>
+                ))}
+            </Select>
+          </FormControl>
+        </DialogContent>
+
+        <DialogActions>
+          <Button onClick={handleClose}>{t('common.cancel') || 'Cancel'}</Button>
+          <Button variant="contained" onClick={handleLaunch}>
+            {t('parameters.test-launch-workflow') || 'Launch Workflow'}
+          </Button>
+        </DialogActions>
+      </Dialog>
+    </>
+  );
+}


### PR DESCRIPTION
Test profiles can now be launched from a dedicated menu.

If a 'test' profile exists in the profiles list, then a 'Test' button is available in the Parameters screen. This option does not rely on user supplied parameters so is enabled regardless of schema validation state.
<img width="500" alt="Screenshot 2025-12-23 at 15 41 39" src="https://github.com/user-attachments/assets/edf8a69b-cc42-40e7-b62d-4594bff22900" />

When selected, a modal dialog appears allowing the user to select additional launch profiles (default is 'docker if that profile exists in the list - however, other options can be selected by the user as required).
<img width="500" alt="Screenshot 2025-12-23 at 15 41 49" src="https://github.com/user-attachments/assets/07e7c56f-78ed-47ac-ac1b-7b4e444da88a" />

Once lauched the pipeline works as normal (dispaying the Monitoring page).

Resolves #67 