### PR TITLE
Fix flaky test

### DIFF
--- a/src/renderer/pages/Settings/Settings.tsx
+++ b/src/renderer/pages/Settings/Settings.tsx
@@ -49,8 +49,10 @@ export default function SettingsPage({
     const newPath = pathRef.current?.value ?? '';
     if (newPath === collectionsPath) return;
     setCollectionsPath(newPath);
-    API.setCollectionsPath(newPath).then(() => { console.log(`Collections path updated: ${newPath}`); });
-  }
+    API.setCollectionsPath(newPath).then(() => {
+      console.log(`Collections path updated: ${newPath}`);
+    });
+  };
 
   const handleLanguageChange = (e) => {
     const newLang = e.target.value;

--- a/src/runners/docker/docker.ts
+++ b/src/runners/docker/docker.ts
@@ -41,7 +41,13 @@ export async function clearStoppedContainers() {
   for (const info of stopped) {
     const container = docker.getContainer(info.Id);
     await container.remove();
-    results.push(info.Id);
+    if (Array.isArray(info.Id)) {
+      // Flatten if multiple IDs
+      results.push(...info.Id);
+    } else {
+      // Single ID
+      results.push(info.Id);
+    }
   }
   return results;
 }


### PR DESCRIPTION
Defensive fix to ensure container IDs are flattened before being pushed to the output list.

Details in #56 