### PR TITLE
Provide certificates for MacOS code signing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,6 +32,17 @@ jobs:
         run: npm ci
 
       - name: Package & publish with electron-builder
-        run: npm run dist
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          APPLE_ID: ${{ secrets.MACOS_NOTARIZATION_APPLE_ID }}
+          APPLE_TEAM_ID: ${{ secrets.MACOS_NOTARIZATION_TEAM_ID }}
+          APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.NOTARIZATION_PWD }}
+          CSC_LINK: "certificate.p12"
+          CSC_BASE64: ${{ secrets.MACOS_CERTIFICATE }}
+          CSC_KEY_PASSWORD: ${{ secrets.MACOS_CERTIFICATE_PASSWORD }}
+        shell: bash
+        run: |
+          if [ "$RUNNER_OS" == "macOS" ]; then
+            echo $CSC_BASE64 | base64 --decode > ${CSC_LINK}
+          fi
+          npm run dist

--- a/assets/entitlements.mac.plist
+++ b/assets/entitlements.mac.plist
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <!-- Allows Just-In-Time compilation required by V8 JavaScript engine in Electron -->
+    <key>com.apple.security.cs.allow-jit</key>
+    <true/>
+
+    <!-- This is needed for the V8 JavaScript engine to function properly -->
+    <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+    <true/>
+    
+    <!-- Allows network connections -->
+    <key>com.apple.security.network.client</key>
+    <true/>
+
+    <!-- Uncomment to allow read and write access to files explicitly selected by the user through system dialogs -->
+    <!-- <key>com.apple.security.files.user-selected.read-write</key>
+    <true/> -->
+
+    <!-- Uncomment to allow read and write access to the user's Downloads directory -->
+    <!-- <key>com.apple.security.files.downloads.read-write</key>
+    <true/> -->
+  </dict>
+</plist>

--- a/package.json
+++ b/package.json
@@ -32,7 +32,9 @@
     ],
     "mac": {
       "target": "dmg",
-      "identity": null
+      "hardenedRuntime": true,
+      "entitlements": "assets/entitlements.mac.plist",
+      "entitlementsInherit": "assets/entitlements.mac.plist"
     },
     "win": {
       "target": "nsis"


### PR DESCRIPTION
- Enable hardened runtime
- Provide certificates for code signing as github secrets
- Use secrets to sign application builds in github actions