### PR TITLE
Make workflow panels clickable with install/source/run actions

### DIFF
--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -18,6 +18,7 @@
     "local-repositories": "Local Repositories",
     "install": "Install",
     "run": "Run",
+    "source": "Source",
     "sync": "Sync",
     "repo-sync-success": "Repository synced successfully",
     "repo-sync-failed": "Repository sync failed",

--- a/src/locales/fr/translation.json
+++ b/src/locales/fr/translation.json
@@ -18,6 +18,7 @@
     "local-repositories": "Dépôts locaux",
     "install": "Installer",
     "run": "Exécuter",
+    "source": "Source",
     "sync": "Synchroniser",
     "repo-sync-success": "Dépôt synchronisé avec succès",
     "repo-sync-failed": "La synchronisation du dépôt a échoué",

--- a/src/renderer/pages/Library/Library.tsx
+++ b/src/renderer/pages/Library/Library.tsx
@@ -126,6 +126,7 @@ function WorkflowCard({
 
   return (
     <Paper
+      id={`card-${workflow.name}`}
       variant="outlined"
       onClick={isRepoInstalled ? (e) => {
         if (menuIsOpen) return;

--- a/src/renderer/pages/Library/Library.tsx
+++ b/src/renderer/pages/Library/Library.tsx
@@ -31,6 +31,13 @@ const resolveHttpUrl = (path, source) => {
   return path;
 };
 
+const repoUrl = (repo) => {
+  if (repo.startsWith('http://') || repo.startsWith('https://')) {
+    return repo.replace(/\.git$/, '');
+  }
+  return `https://github.com/${repo}`;
+};
+
 function WorkflowCard({
   workflow,
   hideWorkflow,
@@ -112,15 +119,33 @@ function WorkflowCard({
     handleMenuClose();
   };
 
+  const handleSourceClick = (e) => {
+    e.stopPropagation();
+    API.openWebPage(repoUrl(workflow.repo));
+  };
+
   return (
     <Paper
       variant="outlined"
+      onClick={isRepoInstalled ? (e) => {
+        if (menuIsOpen) return;
+        runWorkflow();
+      } : undefined}
       sx={{
         p: 1,
+        height: '100%',
+        display: 'flex',
+        flexDirection: 'column',
+        cursor: isRepoInstalled ? 'pointer' : 'default',
         color: scheme['workflow-fg'] ?? 'text.primary',
         background: scheme['workflow-bg'] ?? 'background.paper',
         fontFamily: scheme['font-family'] ?? 'inherit',
-        fontSize: scheme['font-size'] ?? 'inherit'
+        fontSize: scheme['font-size'] ?? 'inherit',
+        filter: !isRepoInstalled ? 'grayscale(60%)' : 'none',
+        transition: 'filter 0.2s, background-color 0.2s',
+        '&:hover': isRepoInstalled
+          ? { backgroundColor: 'action.hover' }
+          : {}
       }}
     >
       <Box
@@ -132,7 +157,7 @@ function WorkflowCard({
       >
         <Typography variant="h6">{workflow.name}</Typography>
         <Box sx={{ ml: 'auto' }}>
-          <IconButton color="inherit" onClick={handleMenuOpen}>
+          <IconButton color="inherit" onClick={(e) => { e.stopPropagation(); handleMenuOpen(e); }}>
             <MoreVertIcon />
           </IconButton>
         </Box>
@@ -148,24 +173,9 @@ function WorkflowCard({
         {workflow.version}{' '}
         {isRepoInstalled && workflow.version === 'latest' && `(${versionInstalled})`}
       </Typography>
-      <Box sx={{ height: 8 }} />
-      <Stack direction="row" spacing={1}>
-        {isRepoInstalled ? (
-          <Button
-            id={`run-${workflow.name}`}
-            size="small"
-            variant="contained"
-            sx={{
-              color: scheme['control-fg'] ?? undefined,
-              background: scheme['control-bg'] ?? undefined,
-              fontFamily: scheme['font-family'] ?? 'inherit',
-              fontSize: scheme['font-size'] ?? 'inherit'
-            }}
-            onClick={runWorkflow}
-          >
-            {t('library.run')}
-          </Button>
-        ) : (
+      <Box sx={{ flex: 1 }} />
+      {!isRepoInstalled && (
+        <Stack direction="row" spacing={1}>
           <Button
             id={`install-${workflow.name}`}
             size="small"
@@ -176,13 +186,21 @@ function WorkflowCard({
               fontFamily: scheme['font-family'] ?? 'inherit',
               fontSize: scheme['font-size'] ?? 'inherit'
             }}
-            onClick={cloneRepo}
+            onClick={(e) => { e.stopPropagation(); cloneRepo(); }}
             loading={loading}
           >
             {t('library.install')}
           </Button>
-        )}
-      </Stack>
+          <Button
+            id={`source-${workflow.name}`}
+            size="small"
+            variant="outlined"
+            onClick={handleSourceClick}
+          >
+            {t('library.source')}
+          </Button>
+        </Stack>
+      )}
     </Paper>
   );
 }

--- a/tests/e2e/ui.spec.ts
+++ b/tests/e2e/ui.spec.ts
@@ -74,8 +74,11 @@ test('clone a repository', async ({ page }) => {
   // Click Install (clone the repository)
   await page.click(`#install-${cssEscape(repo_name)}`);
 
+  // Wait for clone to complete before attempting to run
+  await waitForLogLine(page, /Cloned/, TIMEOUT_60s);
+
   // Create an instance of the workflow (redirects to Parameters page)
-  await page.click(`#run-${cssEscape(repo_name)}`);
+  await page.click(`#card-${cssEscape(repo_name)}`);
   // 'Launch Workflow' button should now be visible
   await expect(page.getByRole('button', { name: 'Launch Workflow' })).toBeVisible({
     timeout: TIMEOUT_10s
@@ -98,7 +101,7 @@ test('launch local workflow', async ({ page }) => {
   const repo_name = 'sleep';
 
   // Create an instance of the workflow (redirects to Parameters page)
-  await page.click(`#run-${cssEscape(repo_name)}`);
+  await page.click(`#card-${cssEscape(repo_name)}`);
 
   // Default display is Description, switch to Parameters tab
   await page.click('#parameters-params-tab');


### PR DESCRIPTION
- Installed panels: whole card is clickable to run, grayscale filter removed
- Uninstalled panels: show Install and Source buttons, muted with grayscale
- Source button opens workflow GitHub URL via API.openWebPage
- Consistent panel height within grid rows (flex column + flexGrow spacer)
- Fix: clicking menu backdrop no longer triggers run

Resolves #207 