### PR TITLE
Augmented PID tracking

### DIFF
--- a/src/main/collection.ts
+++ b/src/main/collection.ts
@@ -8,7 +8,7 @@ import { generateUniqueName } from './repo.js';
 import { cloneRepo, ICloneRepo, getRepoTags, getRepoBranches, parseRepoUrl } from './repo.js';
 import { runWorkflow } from './runner.js';
 import { getEnvironmentStatus, performEnvironmentAction } from '../runners/environment.js';
-import { WorkflowStatus } from '../types/types.js';
+import { ProcessDescriptor, WorkflowStatus } from '../types/types.js';
 import { syncRepo, getWorkflowParams, getWorkflowSchema, isValidWorkflowRepo as checkIsValidWorkflowRepo } from './repo.js';
 import { getConfigPath, getDocumentsPath, locateReports } from './paths.js';
 import { settings, StoreSchema } from './settings.js';
@@ -145,7 +145,7 @@ class WorkflowInstance implements IWorkflowInstance {
   params?: IWorkflowParams;
   status: string;
 
-  pid: number[] = [];
+  processes: ProcessDescriptor[] = [];
 
   constructor({
     id,
@@ -163,8 +163,8 @@ class WorkflowInstance implements IWorkflowInstance {
     this.status = status;
   }
 
-  attachPID(pid: number) {
-    this.pid.push(pid);
+  attachProcess(desc: ProcessDescriptor) {
+    this.processes.push(desc);
   }
 
   async getProgress(): Promise<Record<string, any>> {
@@ -399,19 +399,16 @@ export class Collection {
       const instance = this.workflow_instances.find((inst) => inst.id === run.id);
       if (!instance) {
         const latest_run = run.runs?.length > 0 ? run.runs[run.runs.length - 1] : null;
-        let has_running_pid = false;
-        if (latest_run?.pids?.length > 0) {
-          for (const pid of latest_run.pids) {
-            try {
-              process.kill(pid, 0);
-              has_running_pid = true;
-              break;
-            } catch {
-              // PID not running
-            }
+        let has_running = false;
+        // Try new-style processes first, fall back to old-style pids
+        const descriptors = this.getDescriptorsFromRun(latest_run);
+        for (const desc of descriptors) {
+          if (await this.verifyProcess(desc)) {
+            has_running = true;
+            break;
           }
         }
-        if (!has_running_pid) {
+        if (!has_running) {
           console.log(`Instance ${run.id} found in database but not in filesystem, removing.`);
           db.runs = db.runs.filter((r: any) => r.id !== run.id);
           db_updated = true;
@@ -424,28 +421,41 @@ export class Collection {
       if (run.runs && run.runs.length > 0) {
         const latest_run = run.runs[run.runs.length - 1];
         instance.status = latest_run.status;
-        // If running and PIDs exist, check if still running
-        if (latest_run.status === 'running' && latest_run.pids && latest_run.pids.length > 0) {
-          instance.pid = latest_run.pids;
-          for (const pid of latest_run.pids) {
-            try {
-              process.kill(pid, 0); // Check if process is running
-              console.log(`Instance ${instance.id} has running PID: ${pid}`);
-            } catch {
-              console.log(`Instance ${instance.id} PID ${pid} is not running, updating status.`);
-              // Remove PID from instance
-              instance.pid = instance.pid.filter((p) => p !== pid);
-              // Add termination status to database
-              const progress = await instance.getStatus();
-              const status = progress || 'closed';
-              run.runs.push({
-                datetime: new Date().toISOString(),
-                pids: [],
-                status: status
-              });
-              instance.status = status;
-              db_updated = true;
+        // If running and process descriptors exist, check if still running
+        const descriptors = this.getDescriptorsFromRun(latest_run);
+        if (latest_run.status === 'running' && descriptors.length > 0) {
+          instance.processes = descriptors;
+          const alive: ProcessDescriptor[] = [];
+          for (const desc of descriptors) {
+            const isAlive = await this.verifyProcess(desc);
+            if (isAlive) {
+              alive.push(desc);
+              const tag = desc.containerId
+                ? `container ${desc.containerId.slice(0, 12)}`
+                : `PID ${desc.pid}`;
+              console.log(`Instance ${instance.id} has running ${tag}`);
+            } else {
+              const tag = desc.containerId
+                ? `container ${desc.containerId.slice(0, 12)}`
+                : `PID ${desc.pid}`;
+              console.log(`Instance ${instance.id} ${tag} is not running, updating status.`);
             }
+          }
+          instance.processes = alive;
+          if (alive.length === 0 && descriptors.length > 0) {
+            // All processes dead — update status
+            const progress = await instance.getStatus();
+            const status = progress || 'closed';
+            run.runs.push({
+              datetime: new Date().toISOString(),
+              pids: [],
+              status: status
+            });
+            instance.status = status;
+            db_updated = true;
+          } else if (alive.length !== descriptors.length) {
+            // Some processes died — update DB with cleaned list
+            db_updated = true;
           }
         }
       }
@@ -453,6 +463,23 @@ export class Collection {
     if (db_updated) {
       fs.writeFileSync(db_path, JSON.stringify(db, null, 2));
     }
+  }
+
+  /** Extract ProcessDescriptors from a DB run entry, handling both old and new schema */
+  private getDescriptorsFromRun(run: any): ProcessDescriptor[] {
+    if (!run) return [];
+    // New format
+    if (run.processes && Array.isArray(run.processes) && run.processes.length > 0) {
+      return run.processes;
+    }
+    // Legacy format: `pids: number[]`
+    if (run.pids && Array.isArray(run.pids) && run.pids.length > 0) {
+      return run.pids.map((pid: number) => ({
+        pid,
+        startTime: run.datetime || undefined
+      }));
+    }
+    return [];
   }
 
   private printCollection() {
@@ -466,8 +493,11 @@ export class Collection {
     console.log('Instances in collection:');
     for (const inst of this.workflow_instances) {
       console.log(`- ${inst.id} (${inst.workflow_version.id}) at ${inst.path}`);
-      if (inst.pid.length > 0) {
-        console.log(`  - PIDs: ${inst.pid.join(', ')}`);
+      if (inst.processes.length > 0) {
+        const descs = inst.processes
+          .map((p) => `${p.pid}${p.containerId ? ' (container:' + p.containerId.slice(0, 12) + ')' : ''}`)
+          .join(', ');
+        console.log(`  - Processes: ${descs}`);
       }
     }
   }
@@ -650,27 +680,98 @@ export class Collection {
     }
   };
 
+  /**
+   * Read the command line of a running process for PID-reuse detection.
+   * Returns null when the platform doesn't support it or the PID is gone.
+   */
+  private async getProcessCmd(pid: number): Promise<string | null> {
+    const isWin = process.platform === 'win32';
+    try {
+      if (isWin) {
+        const { execSync } = require('child_process');
+        const out = execSync(
+          `wmic process where processid=${pid} get commandline /format:list`,
+          { encoding: 'utf-8', timeout: 3000 }
+        );
+        const match = out.match(/CommandLine=(.+)/);
+        return match ? match[1].trim() : null;
+      } else {
+        // macOS / Linux — read /proc/<pid>/cmdline (works on both)
+        const cmdline = require('fs').readFileSync(`/proc/${pid}/cmdline`, 'utf-8');
+        return cmdline.replace(/\0/g, ' ').trim();
+      }
+    } catch {
+      return null;
+    }
+  }
+
+  /**
+   * Verify that a process descriptor still refers to the expected OS process.
+   * For Docker containers, inspect via Docker API.
+   */
+  private async verifyProcess(desc: ProcessDescriptor): Promise<boolean> {
+    // Docker containers
+    if (desc.containerId) {
+      try {
+        const { docker } = await import('../runners/docker/docker.js');
+        const container = docker.getContainer(desc.containerId);
+        const info = await container.inspect();
+        return info.State.Running;
+      } catch {
+        return false;
+      }
+    }
+
+    // Standard PID — check liveness first, then verify command line
+    try {
+      process.kill(desc.pid, 0);
+    } catch {
+      return false;
+    }
+
+    // If we have a stored cmd, verify it matches the running process
+    if (desc.cmd) {
+      const actualCmd = await this.getProcessCmd(desc.pid);
+      if (actualCmd !== null && !actualCmd.includes(desc.cmd)) {
+        // The PID is alive but belongs to a different program — PID reuse
+        const excerpt =
+          actualCmd.length > 120 ? actualCmd.slice(0, 120) + '...' : actualCmd;
+        console.warn(
+          `PID ${desc.pid} cmd mismatch: expected "${desc.cmd.slice(0, 80)}", got "${excerpt}"`
+        );
+        return false;
+      }
+    }
+
+    return true;
+  }
+
   async cancelWorkflowInstance(instance: IWorkflowInstance): Promise<void> {
-    // Find instance
     console.log(`Cancelling instance ${instance.id}`);
     const local_instance = this.workflow_instances.find((inst) => inst.id === instance.id);
     if (!local_instance) {
       throw new Error(`Instance ${instance.id} not found in collection.`);
     }
-    if (local_instance.pid.length === 0) {
+    if (local_instance.processes.length === 0) {
       throw new Error(`Instance ${instance.id} has no running process.`);
     }
-    for (const pid of local_instance.pid) {
+    for (const desc of local_instance.processes) {
       try {
-        const success = this.killPID(pid, 'graceful');
-        if (!success) {
-          console.error(`Failed to stop process ${pid} for instance ${instance.id}`);
+        if (desc.containerId) {
+          const { docker } = await import('../runners/docker/docker.js');
+          const container = docker.getContainer(desc.containerId);
+          await container.stop({ t: 10 });
+        } else {
+          const success = this.killPID(desc.pid, 'graceful');
+          if (!success) {
+            console.error(`Failed to stop PID ${desc.pid} for instance ${instance.id}`);
+          }
         }
       } catch (err) {
-        console.error(`Failed to stop process ${pid} for instance ${instance.id}: ${err}`);
+        console.error(`Failed to stop process for instance ${instance.id}: ${err}`);
       }
     }
-    local_instance.pid = [];
+    local_instance.processes = [];
   }
 
   async resetWorkflowInstanceStatus(instance: IWorkflowInstance): Promise<void> {
@@ -679,30 +780,35 @@ export class Collection {
       throw new Error(`Instance ${instance.id} not found in collection.`);
     }
     local_instance.status = WorkflowStatus.Created;
-    local_instance.pid = [];
+    local_instance.processes = [];
   }
 
   async killWorkflowInstance(instance: IWorkflowInstance): Promise<void> {
-    // Find instance
-    console.log(`Cancelling instance ${instance.id}`);
+    console.log(`Killing instance ${instance.id}`);
     const local_instance = this.workflow_instances.find((inst) => inst.id === instance.id);
     if (!local_instance) {
       throw new Error(`Instance ${instance.id} not found in collection.`);
     }
-    if (local_instance.pid.length === 0) {
+    if (local_instance.processes.length === 0) {
       throw new Error(`Instance ${instance.id} has no running process.`);
     }
-    for (const pid of local_instance.pid) {
+    for (const desc of local_instance.processes) {
       try {
-        const success = this.killPID(pid, 'kill');
-        if (!success) {
-          console.error(`Failed to kill process ${pid} for instance ${instance.id}`);
+        if (desc.containerId) {
+          const { docker } = await import('../runners/docker/docker.js');
+          const container = docker.getContainer(desc.containerId);
+          await container.kill();
+        } else {
+          const success = this.killPID(desc.pid, 'kill');
+          if (!success) {
+            console.error(`Failed to kill PID ${desc.pid} for instance ${instance.id}`);
+          }
         }
       } catch (err) {
-        console.error(`Failed to kill process ${pid} for instance ${instance.id}: ${err}`);
+        console.error(`Failed to kill process for instance ${instance.id}: ${err}`);
       }
     }
-    local_instance.pid = [];
+    local_instance.processes = [];
   }
 
   async deleteWorkflowInstance(instance: IWorkflowInstance): Promise<void> {
@@ -715,7 +821,7 @@ export class Collection {
     }
     const local_instance = this.workflow_instances[local_instance_index];
     // Ensure no running processes
-    if (local_instance.pid.length > 0) {
+    if (local_instance.processes.length > 0) {
       await this.killWorkflowInstance(instance);
     }
     // Delete folder
@@ -888,22 +994,26 @@ export class Collection {
     return repos;
   }
 
-  async runWorkflow(instance: IWorkflowInstance, params: IWorkflowParams = {}, opts = {}) {
+  async runWorkflow(
+    instance: IWorkflowInstance,
+    params: IWorkflowParams = {},
+    opts = {}
+  ): Promise<ProcessDescriptor | null> {
     const local_instance = this.workflow_instances.find((inst) => inst.id === instance.id);
     if (!local_instance) {
       throw new Error(`Instance ${instance.id} not found in collection.`);
     }
-    const pid = await runWorkflow({
+    const desc = await runWorkflow({
       instance: instance,
       params: params,
       opts: opts
     });
-    if (!pid) {
+    if (!desc) {
       throw new Error(`Failed to start workflow instance ${instance.id}.`);
     }
-    local_instance.attachPID(pid as number);
+    local_instance.attachProcess(desc);
     this.recordRunWorkflow(instance);
-    return pid;
+    return desc;
   }
 
   recordRunWorkflow(instance: IWorkflowInstance, status = 'running') {
@@ -919,28 +1029,25 @@ export class Collection {
     if (fs.existsSync(db_path)) {
       db = JSON.parse(fs.readFileSync(db_path, 'utf-8'));
     }
+    // Build the run entry with both new structured processes and legacy pids
+    const entry = {
+      datetime: new Date().toISOString(),
+      processes: local_instance.processes,
+      pids: local_instance.processes.map((p) => p.pid).filter((p) => p > 0),
+      status: status
+    };
     // Find existing run
     const existing_run = db.runs.find((r: any) => r.id === local_instance.id);
     if (existing_run) {
       // Append new run
-      existing_run.runs.push({
-        datetime: new Date().toISOString(),
-        pids: local_instance.pid,
-        status: status
-      });
+      existing_run.runs.push(entry);
     } else {
       // Create instance
       db.runs.push({
         id: local_instance.id,
         name: local_instance.name,
         workflow: local_instance.workflow_version.id,
-        runs: [
-          {
-            datetime: new Date().toISOString(),
-            pids: local_instance.pid,
-            status: status
-          }
-        ]
+        runs: [entry]
       });
     }
     // Write DB

--- a/src/main/runner.ts
+++ b/src/main/runner.ts
@@ -5,6 +5,7 @@ import {
   runWorkflow as runWorkflowNextflow
 } from '../runners/nextflow/nextflow.js';
 import { runRepo_Docker } from '../runners/docker/docker.js';
+import { ProcessDescriptor } from '../types/types.js';
 
 export { getEnvironmentStatus, performEnvironmentAction } from '../runners/environment.js';
 
@@ -14,7 +15,11 @@ interface IRunWorkflowArgs {
   opts?: IRunWorkflowOpts;
 }
 
-export async function runWorkflow({ instance, params, opts }: IRunWorkflowArgs) {
+export async function runWorkflow({
+  instance,
+  params,
+  opts
+}: IRunWorkflowArgs): Promise<ProcessDescriptor | null> {
   const projectPath = instance.workflow_version.path;
 
   if (!projectPath || !(await fs.stat(projectPath)).isDirectory()) {

--- a/src/runners/docker/docker.ts
+++ b/src/runners/docker/docker.ts
@@ -7,6 +7,7 @@ import { spawn } from 'child_process';
 import { Readable, Duplex } from 'stream';
 import { promises as fs } from 'fs';
 import { IWorkflowInstance, IWorkflowParams } from '../../main/collection.js'; // should not need to import from main
+import { ProcessDescriptor } from '../../types/types.js';
 
 type paramsT = { [key: string]: any };
 
@@ -140,7 +141,11 @@ export async function runRepo_NextflowDocker(repoPath: string, name: string, par
   return container.id;
 }
 
-export async function runRepo_Docker(repoPath: string, name: string, params: paramsT) {
+export async function runRepo_Docker(
+  repoPath: string,
+  name: string,
+  params: paramsT
+): Promise<ProcessDescriptor> {
   const imageName = name.replace('/', '-');
 
   const tarStream = await docker.buildImage(
@@ -159,7 +164,12 @@ export async function runRepo_Docker(repoPath: string, name: string, params: par
   });
 
   await container.start();
-  return container.id;
+  return {
+    pid: 0,
+    containerId: container.id,
+    cmd: `docker run ${imageName}`,
+    startTime: new Date().toISOString()
+  };
 }
 
 export async function getContainerLogs(containerId: string) {

--- a/src/runners/nextflow/nextflow.ts
+++ b/src/runners/nextflow/nextflow.ts
@@ -7,6 +7,7 @@ import { promises as fs } from 'fs';
 // should not be linking directly to main from here
 import { IWorkflowInstance } from '../../main/collection.js';
 import { getConfigPath } from '../../main/paths.js';
+import { ProcessDescriptor } from '../../types/types.js';
 
 type paramsT = { [key: string]: any };
 
@@ -93,7 +94,7 @@ export async function runWorkflow(
   instance: IWorkflowInstance,
   params: paramsT,
   { resume = false, restart = false, profile = 'standard' }: IRunWorkflowOpts = {}
-) {
+): Promise<ProcessDescriptor | null> {
   const { is_electron, java_binary, jar_file, env } = await get_electron_paths();
 
   // Launch nextflow natively on host system
@@ -180,7 +181,11 @@ export async function runWorkflow(
     }
     p.unref();
 
-    return p.pid;
+    return {
+      pid: p.pid,
+      cmd: cmd,
+      startTime: new Date().toISOString()
+    };
   }
 
   // Unix / macOS launcher
@@ -235,6 +240,9 @@ export async function runWorkflow(
     '--add-opens=java.base/jdk.internal.misc=ALL-UNNAMED'
   ];
 
+  const cmdLine = is_electron
+    ? [java_binary, ...java_flags, '-jar', jar_file, ...cmd].join(' ')
+    : ['nextflow', ...cmd].join(' ');
   console.log(`Spawning nextflow with command: nextflow ${cmd.join(' ')} from ${instancePath}`);
   try {
     let p;
@@ -265,7 +273,11 @@ export async function runWorkflow(
       throw new Error('Failed to spawn nextflow process');
     }
     p.unref(); // allow the parent to exit independently
-    return p.pid;
+    return {
+      pid: p.pid,
+      cmd: cmdLine,
+      startTime: new Date().toISOString()
+    };
   } catch (err) {
     return null;
   }

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -25,6 +25,18 @@ export enum WorkflowStatus {
   Undefined = 'undefined'
 }
 
+// Persistent handle to an OS process (or Docker container) for lifecycle management.
+// Augments a bare PID with enough metadata to detect PID reuse across restarts.
+export interface ProcessDescriptor {
+  pid: number;
+  /** Human-readable command line used to spawn the process (for PID reuse detection) */
+  cmd?: string;
+  /** ISO timestamp of when this descriptor was first captured */
+  startTime?: string;
+  /** Docker container ID (if this is a container-backed workflow) */
+  containerId?: string;
+}
+
 // Process status enumeration
 export enum ProcessStatus {
   Created = 'created',

--- a/tests/unit/collection.test.js
+++ b/tests/unit/collection.test.js
@@ -231,20 +231,20 @@ describe('Collection', () => {
 
   describe('runWorkflow', () => {
     it('delegates to runner and attaches PID', async () => {
-      vi.mocked(runner.runWorkflow).mockResolvedValue(999);
-      const instance = { id: 'test-instance', name: 'test', workflow_version: {}, path: '', pid: [], status: 'created', attachPID: vi.fn() };
+      vi.mocked(runner.runWorkflow).mockResolvedValue({ pid: 999, cmd: 'test-cmd', startTime: new Date().toISOString() });
+      const instance = { id: 'test-instance', name: 'test', workflow_version: {}, path: '', processes: [], status: 'created', attachProcess: vi.fn() };
       collection.workflow_instances = [instance];
-      const spy = vi.spyOn(instance, 'attachPID');
+      const spy = vi.spyOn(instance, 'attachProcess');
 
-      const pid = await collection.runWorkflow(instance, { key: 'val' });
+      const desc = await collection.runWorkflow(instance, { key: 'val' });
 
-      expect(pid).toBe(999);
-      expect(spy).toHaveBeenCalledWith(999);
+      expect(desc.pid).toBe(999);
+      expect(spy).toHaveBeenCalledWith(expect.objectContaining({ pid: 999 }));
     });
 
     it('throws if runner returns null PID', async () => {
       vi.mocked(runner.runWorkflow).mockResolvedValue(null);
-      const instance = { id: 'test-instance', name: 'test', workflow_version: {}, path: '', pid: [], status: 'created' };
+      const instance = { id: 'test-instance', name: 'test', workflow_version: {}, path: '', processes: [], status: 'created' };
       collection.workflow_instances = [instance];
 
       await expect(collection.runWorkflow(instance, {})).rejects.toThrow('Failed to start');
@@ -260,7 +260,7 @@ describe('Collection', () => {
   describe('cancelWorkflowInstance', () => {
     it('kills each PID with graceful signal', async () => {
       const killSpy = vi.spyOn(collection, 'killPID').mockReturnValue(true);
-      const instance = { id: 'test', name: '', workflow_version: {}, path: '', pid: [100, 200], status: 'running' };
+      const instance = { id: 'test', name: '', workflow_version: {}, path: '', processes: [{ pid: 100 }, { pid: 200 }], status: 'running' };
       collection.workflow_instances = [instance];
 
       await collection.cancelWorkflowInstance(instance);
@@ -268,7 +268,7 @@ describe('Collection', () => {
       expect(killSpy).toHaveBeenCalledTimes(2);
       expect(killSpy).toHaveBeenCalledWith(100, 'graceful');
       expect(killSpy).toHaveBeenCalledWith(200, 'graceful');
-      expect(instance.pid).toEqual([]);
+      expect(instance.processes).toEqual([]);
     });
 
     it('throws for unknown instance', async () => {
@@ -276,7 +276,7 @@ describe('Collection', () => {
     });
 
     it('throws if no running PIDs', async () => {
-      const instance = { id: 'test', name: '', workflow_version: {}, path: '', pid: [], status: 'created' };
+      const instance = { id: 'test', name: '', workflow_version: {}, path: '', processes: [], status: 'created' };
       collection.workflow_instances = [instance];
 
       await expect(collection.cancelWorkflowInstance(instance)).rejects.toThrow('no running process');
@@ -286,13 +286,13 @@ describe('Collection', () => {
   describe('killWorkflowInstance', () => {
     it('kills each PID with kill signal', async () => {
       const killSpy = vi.spyOn(collection, 'killPID').mockReturnValue(true);
-      const instance = { id: 'test', name: '', workflow_version: {}, path: '', pid: [100], status: 'running' };
+      const instance = { id: 'test', name: '', workflow_version: {}, path: '', processes: [{ pid: 100 }], status: 'running' };
       collection.workflow_instances = [instance];
 
       await collection.killWorkflowInstance(instance);
 
       expect(killSpy).toHaveBeenCalledWith(100, 'kill');
-      expect(instance.pid).toEqual([]);
+      expect(instance.processes).toEqual([]);
     });
   });
 
@@ -300,7 +300,7 @@ describe('Collection', () => {
     it('removes instance folder and removes from list', async () => {
       const instPath = path.join(tmpDir, 'instances', 'owner', 'repo@v1.0', 'test-instance');
       fs.mkdirSync(instPath, { recursive: true });
-      const instance = { id: 'test-instance', name: 'test', workflow_version: {}, path: instPath, pid: [], status: 'created' };
+      const instance = { id: 'test-instance', name: 'test', workflow_version: {}, path: instPath, processes: [], status: 'created' };
       collection.workflow_instances = [instance];
 
       await collection.deleteWorkflowInstance(instance);
@@ -317,8 +317,8 @@ describe('Collection', () => {
   describe('listWorkflowInstances', () => {
     it('returns all instances', async () => {
       const instances = [
-        { id: 'a', name: 'a', workflow_version: {}, path: '', pid: [], status: 'created' },
-        { id: 'b', name: 'b', workflow_version: {}, path: '', pid: [], status: 'created' }
+        { id: 'a', name: 'a', workflow_version: {}, path: '', processes: [], status: 'created' },
+        { id: 'b', name: 'b', workflow_version: {}, path: '', processes: [], status: 'created' }
       ];
       collection.workflow_instances = instances;
 
@@ -349,7 +349,7 @@ describe('Collection', () => {
       const instPath = path.join(tmpDir, 'instances', 'test-instance');
       fs.mkdirSync(instPath, { recursive: true });
       fs.writeFileSync(path.join(instPath, 'params.json'), JSON.stringify({ key: 'val' }), 'utf8');
-      const instance = { id: 'test', name: 'test', workflow_version: {}, path: instPath, pid: [], status: 'created' };
+      const instance = { id: 'test', name: 'test', workflow_version: {}, path: instPath, processes: [], status: 'created' };
       collection.workflow_instances = [instance];
 
       const params = await collection.getWorkflowInstanceParams(instance);
@@ -358,7 +358,7 @@ describe('Collection', () => {
     });
 
     it('returns empty object if params.json missing', async () => {
-      const instance = { id: 'test', name: 'test', workflow_version: {}, path: '/nonexistent', pid: [], status: 'created' };
+      const instance = { id: 'test', name: 'test', workflow_version: {}, path: '/nonexistent', processes: [], status: 'created' };
       collection.workflow_instances = [instance];
 
       const params = await collection.getWorkflowInstanceParams(instance);
@@ -373,7 +373,7 @@ describe('Collection', () => {
         id: 'test',
         workflow_version: { path: '/x' },
         path: '/x',
-        pid: [],
+        processes: [],
         getProgress: vi.fn().mockResolvedValue({ workflow: [], group: [] })
       };
       collection.workflow_instances = [instance];
@@ -388,7 +388,7 @@ describe('Collection', () => {
         id: 'test',
         workflow_version: { path: '/x' },
         path: '/x',
-        pid: [],
+        processes: [],
         getProgress: vi.fn().mockResolvedValue({
           workflow: [{ status: 'completed' }],
           group: []
@@ -407,7 +407,7 @@ describe('Collection', () => {
       const wfPath = path.join(tmpDir, 'wf');
       fs.mkdirSync(wfPath, { recursive: true });
       fs.writeFileSync(path.join(wfPath, 'README.md'), '# Test', 'utf8');
-      const instance = { id: 'test', name: 'test', workflow_version: { path: wfPath }, path: '', pid: [] };
+      const instance = { id: 'test', name: 'test', workflow_version: { path: wfPath }, path: '', processes: [] };
 
       const readme = collection.getWorkflowReadme(instance);
 
@@ -415,7 +415,7 @@ describe('Collection', () => {
     });
 
     it('throws if no README.md', () => {
-      const instance = { id: 'test', name: 'test', workflow_version: { path: '/nonexistent' }, path: '', pid: [] };
+      const instance = { id: 'test', name: 'test', workflow_version: { path: '/nonexistent' }, path: '', processes: [] };
 
       expect(() => collection.getWorkflowReadme(instance)).toThrow('No README.md');
     });
@@ -426,7 +426,7 @@ describe('Collection', () => {
       const wfPath = path.join(tmpDir, 'wf');
       fs.mkdirSync(wfPath, { recursive: true });
       fs.writeFileSync(path.join(wfPath, 'LICENSE'), 'MIT', 'utf8');
-      const instance = { id: 'test', name: 'test', workflow_version: { path: wfPath }, path: '', pid: [] };
+      const instance = { id: 'test', name: 'test', workflow_version: { path: wfPath }, path: '', processes: [] };
 
       const license = collection.getWorkflowLicense(instance);
 
@@ -473,7 +473,7 @@ describe('Collection', () => {
       const workDir = path.join(instPath, 'work', 'ab', '123456somehash');
       fs.mkdirSync(workDir, { recursive: true });
       fs.writeFileSync(path.join(workDir, '.command.out'), 'stdout content', 'utf8');
-      const instance = { id: 'test', name: 'test', workflow_version: {}, path: instPath, pid: [], status: 'created' };
+      const instance = { id: 'test', name: 'test', workflow_version: {}, path: instPath, processes: [], status: 'created' };
       collection.workflow_instances = [instance];
 
       const log = collection.getWorkLog(instance, 'ab/123456', 'stdout');
@@ -482,14 +482,14 @@ describe('Collection', () => {
     });
 
     it('throws for unknown log type', () => {
-      const instance = { id: 'test', name: 'test', workflow_version: {}, path: tmpDir, pid: [] };
+      const instance = { id: 'test', name: 'test', workflow_version: {}, path: tmpDir, processes: [] };
       collection.workflow_instances = [instance];
 
       expect(() => collection.getWorkLog(instance, 'ab/123456', 'invalid')).toThrow('Unknown log type');
     });
 
     it('throws for invalid work ID format', () => {
-      const instance = { id: 'test', name: 'test', workflow_version: {}, path: tmpDir, pid: [] };
+      const instance = { id: 'test', name: 'test', workflow_version: {}, path: tmpDir, processes: [] };
       collection.workflow_instances = [instance];
 
       expect(() => collection.getWorkLog(instance, 'bad-id', 'stdout')).toThrow('Invalid work ID');
@@ -500,7 +500,7 @@ describe('Collection', () => {
     it('opens the instance path via shell', async () => {
       const instPath = path.join(tmpDir, 'instances', 'test-instance');
       fs.mkdirSync(instPath, { recursive: true });
-      const instance = { id: 'test', name: 'test', workflow_version: {}, path: instPath, pid: [] };
+      const instance = { id: 'test', name: 'test', workflow_version: {}, path: instPath, processes: [] };
       collection.workflow_instances = [instance];
 
       await collection.openResultsFolder(instance);
@@ -509,7 +509,7 @@ describe('Collection', () => {
     });
 
     it('throws for missing folder', async () => {
-      const instance = { id: 'test', name: 'test', workflow_version: {}, path: '/nonexistent', pid: [] };
+      const instance = { id: 'test', name: 'test', workflow_version: {}, path: '/nonexistent', processes: [] };
       collection.workflow_instances = [instance];
 
       await expect(collection.openResultsFolder(instance)).rejects.toThrow('does not exist');
@@ -521,7 +521,7 @@ describe('Collection', () => {
       const instPath = path.join(tmpDir, 'instances', 'test-instance');
       const workDir = path.join(instPath, 'work', 'ab', '123456somehash');
       fs.mkdirSync(workDir, { recursive: true });
-      const instance = { id: 'test', name: 'test', workflow_version: {}, path: instPath, pid: [] };
+      const instance = { id: 'test', name: 'test', workflow_version: {}, path: instPath, processes: [] };
       collection.workflow_instances = [instance];
 
       await collection.openWorkFolder(instance, 'ab/123456');
@@ -788,7 +788,7 @@ describe('Collection', () => {
   describe('getAvailableProfiles', () => {
     it('delegates to nextflow runner', async () => {
       vi.mocked(getAvailableProfiles).mockResolvedValue(['standard', 'test']);
-      const instance = { id: 'test', name: 'test', workflow_version: { path: '/x' }, path: '/x', pid: [] };
+      const instance = { id: 'test', name: 'test', workflow_version: { path: '/x' }, path: '/x', processes: [] };
       collection.workflow_instances = [instance];
 
       const profiles = await collection.getAvailableProfiles(instance);
@@ -802,7 +802,7 @@ describe('Collection', () => {
       const instPath = path.join(tmpDir, 'instances', 'test-instance');
       fs.mkdirSync(instPath, { recursive: true });
       fs.writeFileSync(path.join(instPath, 'stdout.log'), 'log content', 'utf8');
-      const instance = { id: 'test', name: 'test', workflow_version: {}, path: instPath, pid: [], status: 'created' };
+      const instance = { id: 'test', name: 'test', workflow_version: {}, path: instPath, processes: [], status: 'created' };
 
       const logs = collection.getWorkflowInstanceLogs(instance, 'stdout');
 
@@ -810,7 +810,7 @@ describe('Collection', () => {
     });
 
     it('returns empty string if log file missing', () => {
-      const instance = { id: 'test', name: 'test', workflow_version: {}, path: '/nonexistent', pid: [] };
+      const instance = { id: 'test', name: 'test', workflow_version: {}, path: '/nonexistent', processes: [] };
 
       const logs = collection.getWorkflowInstanceLogs(instance, 'stdout');
 
@@ -821,7 +821,7 @@ describe('Collection', () => {
   describe('getInstanceReportsList', () => {
     it('delegates to locateReports', () => {
       vi.mocked(paths.locateReports).mockReturnValue([{ id: '1', name: 'report', path: '/r.html', shortPath: 'r.html' }]);
-      const instance = { id: 'test', name: 'test', workflow_version: {}, path: '/some/path', pid: [] };
+      const instance = { id: 'test', name: 'test', workflow_version: {}, path: '/some/path', processes: [] };
 
       const reports = collection.getInstanceReportsList(instance);
 

--- a/tests/unit/docker.test.js
+++ b/tests/unit/docker.test.js
@@ -180,7 +180,7 @@ describe('docker module', () => {
       mockBuildImage.mockResolvedValue(tarStream);
       mockContainer.start.mockResolvedValue(undefined);
 
-      const id = await docker.runRepo_Docker('/repo/path', 'my/repo', {});
+      const desc = await docker.runRepo_Docker('/repo/path', 'my/repo', {});
 
       expect(mockBuildImage).toHaveBeenCalledWith(
         { context: '/repo/path', src: ['Dockerfile'] },
@@ -196,7 +196,8 @@ describe('docker module', () => {
         Tty: true,
       });
       expect(mockContainer.start).toHaveBeenCalled();
-      expect(id).toBe('container-id-123');
+      expect(desc.containerId).toBe('container-id-123');
+      expect(desc.pid).toBe(0);
     });
 
     it('throws when build fails', async () => {

--- a/tests/unit/nextflow.test.js
+++ b/tests/unit/nextflow.test.js
@@ -203,7 +203,8 @@ describe('nextflow', () => {
     it('returns the spawned process PID', async () => {
       const pid = await runWorkflow(makeInstance(), {});
 
-      expect(pid).toBe(12345);
+      expect(pid.pid).toBe(12345);
+      expect(pid.cmd).toContain('nextflow run');
     });
 
     it('calls unref on the child process', async () => {
@@ -351,7 +352,8 @@ describe('nextflow', () => {
 
       const pid = await winRunWorkflow(makeInstance({ path: 'C:\\test' }), {});
 
-      expect(pid).toBe(999);
+      expect(pid.pid).toBe(999);
+      expect(pid.cmd).toContain('nextflow run');
     });
 
     it('throws when wsl process has no pid', async () => {


### PR DESCRIPTION
Augment PID tracking with command-line verification to prevent PID-reuse bugs

- Introduce ProcessDescriptor type (pid, cmd, startTime, containerId)
- Replace raw pid: number[] with processes: ProcessDescriptor[]
- Capture spawn command line in nextflow.ts and return with PID
- Add verifyProcess() — reads /proc/<pid>/cmdline (Unix) or wmic (Windows) to confirm the running process matches the stored command
- Docker containers now tracked by containerId (via Docker API inspect) instead of casting string IDs to number → NaN
- Database persists both new  and legacy  (backward compat)
- All lifecycle methods (cancel/kill/delete) handle container descriptors
- Fix docker.ts return type, runner.ts return type
- Update all tests for new API shape

Resolves #21 