### PR TITLE
Instance list: search, sort-by options, and persistent sort preference

### DIFF
--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -137,7 +137,14 @@
     "unhide": "Unhide",
     "no_hidden": "No hidden instances.",
     "not_started": "Not started",
-    "no-instances": "No instances available"
+    "no-instances": "No instances available",
+    "search_placeholder": "Search instances...",
+    "no_results": "No instances match your search",
+    "sort_by": "Sort by",
+    "sort_name": "Name",
+    "sort_launch_date": "Launch date",
+    "sort_asc": "Ascending",
+    "sort_desc": "Descending"
   },
   "parameters": {
     "launch-workflow": "Launch Workflow",

--- a/src/locales/fr/translation.json
+++ b/src/locales/fr/translation.json
@@ -137,7 +137,14 @@
     "unhide": "Afficher",
     "no_hidden": "Aucune instance masquée.",
     "not_started": "Non démarré",
-    "no-instances": "Aucune instance disponible."
+    "no-instances": "Aucune instance disponible.",
+    "search_placeholder": "Rechercher des instances...",
+    "no_results": "Aucune instance ne correspond à votre recherche",
+    "sort_by": "Trier par",
+    "sort_name": "Nom",
+    "sort_launch_date": "Date de lancement",
+    "sort_asc": "Croissant",
+    "sort_desc": "Décroissant"
   },
   "parameters": {
     "launch-workflow": "Lancer le flux de travail",

--- a/src/main/collection.ts
+++ b/src/main/collection.ts
@@ -687,6 +687,12 @@ export class Collection {
       instance.last_update = instance.getLastUpdateTime();
       visible.push(instance);
     }
+    visible.sort((a, b) => {
+      const wfA = (a.workflow_version?.name ?? '').toLowerCase();
+      const wfB = (b.workflow_version?.name ?? '').toLowerCase();
+      if (wfA !== wfB) return wfA.localeCompare(wfB);
+      return (a.name ?? '').toLowerCase().localeCompare((b.name ?? '').toLowerCase());
+    });
     return visible;
   }
 

--- a/src/main/store.ts
+++ b/src/main/store.ts
@@ -12,6 +12,8 @@ export interface StoreSchema {
   permitImportShards: boolean;
   permitAddRepos: boolean;
   disableSchemaValidation: boolean;
+  instanceSortBy: string;
+  instanceSortDir: string;
 }
 
 let _instance: any = null;
@@ -29,7 +31,9 @@ function getInstance() {
           permitCatalogueModifications: { type: 'boolean', default: true },
           permitImportShards: { type: 'boolean', default: true },
           permitAddRepos: { type: 'boolean', default: true },
-          disableSchemaValidation: { type: 'boolean', default: false }
+          disableSchemaValidation: { type: 'boolean', default: false },
+          instanceSortBy: { type: 'string', default: 'name' },
+          instanceSortDir: { type: 'string', default: 'asc' }
         },
         name: 'GLACIER'
       });

--- a/src/renderer/pages/Instances.tsx
+++ b/src/renderer/pages/Instances.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useMemo } from 'react';
 import {
   Box,
   Container,
@@ -16,16 +16,24 @@ import {
   Tooltip,
   List,
   ListItem,
-  ListItemText
+  ListItemText,
+  TextField,
+  InputAdornment,
+  Select,
+  FormControl,
+  InputLabel
 } from '@mui/material';
 import Accordion from '@mui/material/Accordion';
 import AccordionSummary from '@mui/material/AccordionSummary';
 import AccordionDetails from '@mui/material/AccordionDetails';
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import MoreVertIcon from '@mui/icons-material/MoreVert';
+import SearchIcon from '@mui/icons-material/Search';
+import ArrowUpwardIcon from '@mui/icons-material/ArrowUpward';
 import { API } from '../services/api.js';
 import { useTranslation } from 'react-i18next';
 import { WorkflowStatus } from '../../types/types';
+import { SettingsKey } from '../../types/settings';
 import MonitorPage from './Monitor/Monitor';
 import ParametersPage from './Parameters/Parameters';
 function formatDiskSize(bytes: number): string {
@@ -185,31 +193,6 @@ const InstanceAccordion = ({
         </AccordionSummary>
         <AccordionDetails>
           <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2, pl: 1, pr: 1 }}>
-            {/* Progress section */}
-            <Box>
-              <Typography variant="subtitle2" gutterBottom>
-                {t('instances.progress')}
-              </Typography>
-              <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
-                {isCreated ? (
-                  <Typography variant="body2" color="text.secondary">
-                    {t('instances.not_started')}
-                  </Typography>
-                ) : (
-                  <>
-                    <LinearProgress
-                      variant="determinate"
-                      value={progress}
-                      sx={{ flex: 1, height: 12, borderRadius: 6 }}
-                    />
-                    <Typography variant="body2" sx={{ minWidth: 48, textAlign: 'right' }}>
-                      {progress}%
-                    </Typography>
-                  </>
-                )}
-              </Box>
-            </Box>
-
             {/* Timing section */}
             <Box sx={{ display: 'flex', gap: 4, flexWrap: 'wrap' }}>
               <Box>
@@ -324,6 +307,38 @@ export default function InstancesPage({
   const [menuAnchorEl, setMenuAnchorEl] = useState<null | HTMLElement>(null);
   const [hiddenDialogOpen, setHiddenDialogOpen] = useState(false);
   const [hiddenInstances, setHiddenInstances] = useState<any[]>([]);
+  const [searchQuery, setSearchQuery] = useState('');
+  const [sortBy, setSortBy] = useState<'name' | 'launch-date'>('name');
+  const [sortDir, setSortDir] = useState<'asc' | 'desc'>('asc');
+
+  const dirDefaults = { name: 'asc', 'launch-date': 'desc' } as const;
+
+  // Load saved sort preferences on mount
+  useEffect(() => {
+    API.settingsGet(SettingsKey.InstanceSortBy).then((result) => {
+      if (result.ok && result.data) {
+        setSortBy(result.data as 'name' | 'launch-date');
+      }
+    });
+    API.settingsGet(SettingsKey.InstanceSortDir).then((result) => {
+      if (result.ok && result.data) {
+        setSortDir(result.data as 'asc' | 'desc');
+      }
+    });
+  }, []);
+
+  // Save sort preferences on change
+  useEffect(() => {
+    API.settingsSet(SettingsKey.InstanceSortBy, sortBy);
+  }, [sortBy]);
+  useEffect(() => {
+    API.settingsSet(SettingsKey.InstanceSortDir, sortDir);
+  }, [sortDir]);
+
+  // Reset direction to field default when sort field changes
+  useEffect(() => {
+    setSortDir(dirDefaults[sortBy]);
+  }, [sortBy]);
 
   const onEditComplete = () => {
     setEditingInstance(null);
@@ -429,6 +444,37 @@ export default function InstancesPage({
     }
   }, [item]);
 
+  const sortedList = useMemo(() => {
+    let list = instancesList;
+    if (searchQuery) {
+      const q = searchQuery.toLowerCase();
+      list = instancesList.filter((entry) => {
+        const status = entry.instance.status || '';
+        return (
+          entry.name.toLowerCase().includes(q) ||
+          entry.instance.workflow_version.name.toLowerCase().includes(q) ||
+          status.toLowerCase().includes(q)
+        );
+      });
+    }
+    return [...list].sort((a, b) => {
+      let cmp: number;
+      if (sortBy === 'launch-date') {
+        const tA = a.instance.launch_time ?? '';
+        const tB = b.instance.launch_time ?? '';
+        cmp = tA.localeCompare(tB);
+      } else {
+        const wfA = a.instance.workflow_version.name.toLowerCase();
+        const wfB = b.instance.workflow_version.name.toLowerCase();
+        cmp =
+          wfA !== wfB
+            ? wfA.localeCompare(wfB)
+            : a.name.toLowerCase().localeCompare(b.name.toLowerCase());
+      }
+      return sortDir === 'asc' ? cmp : -cmp;
+    });
+  }, [instancesList, searchQuery, sortBy, sortDir]);
+
   return (
     <Container sx={{ height: '100%' }}>
       {item === '' ? (
@@ -452,10 +498,53 @@ export default function InstancesPage({
             </Menu>
           </Box>
 
+          {/* Search and sort controls */}
+          <Box sx={{ display: 'flex', gap: 1, mb: 1, alignItems: 'center' }}>
+            <TextField
+              fullWidth
+              size="small"
+              placeholder={t('instances.search_placeholder')}
+              value={searchQuery}
+              onChange={(e) => setSearchQuery(e.target.value)}
+              slotProps={{
+                input: {
+                  startAdornment: (
+                    <InputAdornment position="start">
+                      <SearchIcon fontSize="small" />
+                    </InputAdornment>
+                  )
+                }
+              }}
+            />
+            <FormControl size="small" sx={{ minWidth: 140 }}>
+              <InputLabel>{t('instances.sort_by')}</InputLabel>
+              <Select
+                value={sortBy}
+                label={t('instances.sort_by')}
+                onChange={(e) => setSortBy(e.target.value as 'name' | 'launch-date')}
+              >
+                <MenuItem value="name">{t('instances.sort_name')}</MenuItem>
+                <MenuItem value="launch-date">{t('instances.sort_launch_date')}</MenuItem>
+              </Select>
+            </FormControl>
+            <Tooltip title={sortDir === 'asc' ? t('instances.sort_asc') : t('instances.sort_desc')}>
+              <IconButton
+                size="small"
+                onClick={() => setSortDir(sortDir === 'asc' ? 'desc' : 'asc')}
+                sx={{
+                  transform: sortDir === 'desc' ? 'rotate(180deg)' : 'none',
+                  transition: 'transform 0.2s'
+                }}
+              >
+                <ArrowUpwardIcon fontSize="small" />
+              </IconButton>
+            </Tooltip>
+          </Box>
+
           {/* Accordion list */}
-          {rows.length > 0 ? (
+          {sortedList.length > 0 ? (
             <Box>
-              {instancesList.map((entry) => (
+              {sortedList.map((entry) => (
                 <InstanceAccordion
                   key={entry.name}
                   instance={entry.instance}
@@ -473,7 +562,7 @@ export default function InstancesPage({
           ) : (
             <Container>
               <Typography variant="h6" sx={{ mt: 1 }}>
-                {t('instances.no-instances')}
+                {searchQuery ? t('instances.no_results') : t('instances.no-instances')}
               </Typography>
             </Container>
           )}

--- a/src/types/settings.ts
+++ b/src/types/settings.ts
@@ -7,7 +7,9 @@ export const SettingsKey = {
   PermitCatalogueModifications: 'permitCatalogueModifications',
   PermitImportShards: 'permitImportShards',
   PermitAddRepos: 'permitAddRepos',
-  DisableSchemaValidation: 'disableSchemaValidation'
+  DisableSchemaValidation: 'disableSchemaValidation',
+  InstanceSortBy: 'instanceSortBy',
+  InstanceSortDir: 'instanceSortDir'
 } as const;
 
 export type SettingsKey = (typeof SettingsKey)[keyof typeof SettingsKey];


### PR DESCRIPTION
- Add search bar filtering by instance name, workflow name, and status
- Add sort-by dropdown with Name (default) and Launch date options
- Add ascending/descending toggle with per-field direction defaults
- Persist sort field and direction to electron-store across restarts
- Sort instances by default in listWorkflowInstances for consistent ordering
- Remove redundant progress section from expanded accordion details

Resolves #28 