### PR TITLE
Add create-folder, defaults button, and minor UI fixes

### DIFF
--- a/api-server/index.js
+++ b/api-server/index.js
@@ -355,6 +355,10 @@ app.post('/api/set-documents-path', async (req, res) =>
   post_response(res, call(collection.setDocumentsPath.bind(collection), req.body.path))
 );
 
+app.post('/api/get-default-paths', async (req, res) =>
+  post_response(res, call(collection.getDefaultPaths.bind(collection)))
+);
+
 app.post('/api/get-missing-paths', async (req, res) =>
   post_response(res, call(collection.getMissingPaths.bind(collection)))
 );
@@ -422,6 +426,14 @@ app.post('/api/perform-environment-action', async (req, res) =>
 app.post('/api/get-system-resources', async (req, res) =>
   post_response(res, call(collection.getSystemResources.bind(collection)))
 );
+
+app.post('/api/fs-mkdir', async (req, res) => {
+  const { path: dirPath } = req.body;
+  post_response(res, call(async () => {
+    const fs = await import('fs');
+    fs.mkdirSync(dirPath, { recursive: true });
+  }));
+});
 
 app.post('/api/write-text-file', async (req, res) => {
   const fs = await import('fs');

--- a/src/main/collection.ts
+++ b/src/main/collection.ts
@@ -10,7 +10,13 @@ import { runWorkflow } from './runner.js';
 import { getEnvironmentStatus, performEnvironmentAction } from '../runners/environment.js';
 import { ProcessDescriptor, WorkflowStatus } from '../types/types.js';
 import { syncRepo, getWorkflowParams, getWorkflowSchema, isValidWorkflowRepo as checkIsValidWorkflowRepo } from './repo.js';
-import { getConfigPath, getDocumentsPath, locateReports } from './paths.js';
+import {
+  getConfigPath,
+  getDocumentsPath,
+  locateReports,
+  getDefaultConfigDir,
+  getDefaultDocumentsDir
+} from './paths.js';
 import { settings, StoreSchema } from './settings.js';
 import { importShard, queryShardStatus } from './shard.js';
 
@@ -346,6 +352,13 @@ export class Collection {
     await this.parseCollection();
     this.starting_up = false;
     return missing;
+  }
+
+  getDefaultPaths(): Record<string, string> {
+    return {
+      config: getDefaultConfigDir(),
+      documents: getDefaultDocumentsDir()
+    };
   }
 
   getMissingPaths(): Record<string, boolean> {

--- a/src/main/ipc-handlers.ts
+++ b/src/main/ipc-handlers.ts
@@ -159,6 +159,10 @@ export function registerIpcHandlers() {
     return call(collection.setDocumentsPath.bind(collection), path);
   });
 
+  ipcMain.handle('get-default-paths', () => {
+    return call(collection.getDefaultPaths.bind(collection));
+  });
+
   ipcMain.handle('get-missing-paths', () => {
     return call(collection.getMissingPaths.bind(collection));
   });

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -66,7 +66,7 @@ ipcMain.handle('pick-file', async (_evt, opts?: { filters?: Electron.FileFilter[
 ipcMain.handle('pick-directory', async () => {
   return call(async () => {
     const res = await dialog.showOpenDialog(win!, {
-      properties: ['openDirectory']
+      properties: ['openDirectory', 'createDirectory']
     });
     return res.canceled ? null : (res.filePaths[0] ?? null);
   });
@@ -75,7 +75,7 @@ ipcMain.handle('pick-directory', async () => {
 ipcMain.handle('pick-file-or-directory', async (_, options) => {
   return call(async () => {
     const result = await dialog.showOpenDialog({
-      properties: ['openFile', 'openDirectory'],
+      properties: ['openFile', 'openDirectory', 'createDirectory'],
       filters: options?.filters
     });
     return result.canceled ? null : (result.filePaths[0] ?? null);

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -44,6 +44,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
   setConfigPath: (path: string) => ipcRenderer.invoke('set-config-path', path),
   getDocumentsPath: () => ipcRenderer.invoke('get-documents-path'),
   setDocumentsPath: (path: string) => ipcRenderer.invoke('set-documents-path', path),
+  getDefaultPaths: () => ipcRenderer.invoke('get-default-paths'),
   getMissingPaths: () => ipcRenderer.invoke('get-missing-paths'),
   getCollectionRepos: () => ipcRenderer.invoke('get-collection-repos'),
   addCatalogue: (repoUrl: string, version: string) =>

--- a/src/renderer/components/FileBrowserDialog.tsx
+++ b/src/renderer/components/FileBrowserDialog.tsx
@@ -25,6 +25,7 @@ import InsertDriveFileIcon from '@mui/icons-material/InsertDriveFile';
 import ArrowUpwardIcon from '@mui/icons-material/ArrowUpward';
 import ArrowBackIcon from '@mui/icons-material/ArrowBack';
 import ArrowForwardIcon from '@mui/icons-material/ArrowForward';
+import CreateNewFolderIcon from '@mui/icons-material/CreateNewFolder';
 
 interface FileEntry {
   name: string;
@@ -90,6 +91,8 @@ export default function FileBrowserDialog({ open, mode, filters, defaultPath, on
   );
   const [history, setHistory] = useState<string[]>([]);
   const [historyIndex, setHistoryIndex] = useState(-1);
+  const [showCreateDialog, setShowCreateDialog] = useState(false);
+  const [newFolderName, setNewFolderName] = useState('');
 
   const isSaveMode = mode === 'save';
 
@@ -197,6 +200,33 @@ export default function FileBrowserDialog({ open, mode, filters, defaultPath, on
     }
   }, [offset, total, loading, currentPath, showHidden]);
 
+  const handleCreateFolder = useCallback(async () => {
+    setNewFolderName('');
+    setShowCreateDialog(true);
+  }, []);
+
+  const handleCreateFolderConfirm = useCallback(async () => {
+    if (!newFolderName.trim()) return;
+    setShowCreateDialog(false);
+    try {
+      const res = await fetch('/api/fs-mkdir', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ path: currentPath + '/' + newFolderName.trim() })
+      });
+      const result = await res.json();
+      if (!result.ok) {
+        setError(
+          'Failed to create folder: ' + (result.error?.message ?? 'Unknown error')
+        );
+      } else {
+        loadDir(currentPath, true);
+      }
+    } catch (err: any) {
+      setError('Failed to create folder: ' + (err.message ?? 'Unknown error'));
+    }
+  }, [newFolderName, currentPath, loadDir]);
+
   useEffect(() => {
     if (!open) return;
     (async () => {
@@ -263,7 +293,7 @@ export default function FileBrowserDialog({ open, mode, filters, defaultPath, on
   const confirmDisabled = isSaveMode ? !filename.trim() : !selectedPath;
 
   return (
-    <Dialog open={open} onClose={() => onClose(null)} maxWidth="md" fullWidth>
+    <><Dialog open={open} onClose={() => onClose(null)} maxWidth="md" fullWidth>
       <DialogTitle>{getDialogTitle()}</DialogTitle>
       <DialogContent dividers sx={{ display: 'flex', flexDirection: 'column', minHeight: 400 }}>
         {error && (
@@ -281,6 +311,9 @@ export default function FileBrowserDialog({ open, mode, filters, defaultPath, on
           </IconButton>
           <IconButton size="small" onClick={goUp} disabled={!parentPath}>
             <ArrowUpwardIcon fontSize="small" />
+          </IconButton>
+          <IconButton size="small" onClick={handleCreateFolder} title="New Folder">
+            <CreateNewFolderIcon fontSize="small" />
           </IconButton>
           <Breadcrumbs sx={{ flexGrow: 1, ml: 1 }} maxItems={4}>
             <Link
@@ -424,5 +457,29 @@ export default function FileBrowserDialog({ open, mode, filters, defaultPath, on
         </Button>
       </DialogActions>
     </Dialog>
+    <Dialog open={showCreateDialog} onClose={() => setShowCreateDialog(false)} maxWidth="xs" fullWidth>
+      <DialogTitle>New Folder</DialogTitle>
+        <DialogContent>
+          <TextField
+            autoFocus
+            fullWidth
+            size="small"
+            label="Folder name"
+            sx={{ mt: 1 }}
+          value={newFolderName}
+          onChange={(e) => setNewFolderName(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter') handleCreateFolderConfirm();
+          }}
+        />
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={() => setShowCreateDialog(false)}>Cancel</Button>
+        <Button onClick={handleCreateFolderConfirm} variant="contained" disabled={!newFolderName.trim()}>
+          Create
+        </Button>
+      </DialogActions>
+    </Dialog>
+    </>
   );
 }

--- a/src/renderer/pages/Instances.tsx
+++ b/src/renderer/pages/Instances.tsx
@@ -228,6 +228,13 @@ const InstanceAccordion = ({
               <Button
                 variant="outlined"
                 size="small"
+                onClick={handleOpenDetails}
+              >
+                {t('instances.view_details')}
+              </Button>
+              <Button
+                variant="outlined"
+                size="small"
                 onClick={handleOpenReports}
                 disabled={isCreated}
               >
@@ -239,9 +246,6 @@ const InstanceAccordion = ({
                 onClick={() => API.openResultsFolder(instance)}
               >
                 {t('instances.open_output_folder')}
-              </Button>
-              <Button variant="text" size="small" onClick={handleOpenDetails}>
-                {t('instances.view_details')}
               </Button>
               <Box sx={{ flex: 1 }} />
               <Button

--- a/src/renderer/pages/Main.tsx
+++ b/src/renderer/pages/Main.tsx
@@ -134,6 +134,14 @@ export default function MainPage({ darkMode, setDarkMode }) {
     if (result.ok && result.data) setPendingDocumentsPath(result.data);
   };
 
+  const handleDefaults = async () => {
+    const result = await API.getDefaultPaths();
+    if (result.ok && result.data) {
+      setPendingConfigPath(result.data.config);
+      setPendingDocumentsPath(result.data.documents);
+    }
+  };
+
   const handleConfirmPaths = async () => {
     await API.setConfigPath(pendingConfigPath);
     await API.setDocumentsPath(pendingDocumentsPath);
@@ -343,6 +351,7 @@ export default function MainPage({ darkMode, setDarkMode }) {
           </Typography>
         </DialogContent>
         <DialogActions>
+          <Button onClick={handleDefaults}>{t('setup.defaults', 'Defaults')}</Button>
           <Button variant="contained" onClick={handleConfirmPaths} id="setup-continue-button">
             {t('setup.continue', 'Continue')}
           </Button>

--- a/src/renderer/services/api.ts
+++ b/src/renderer/services/api.ts
@@ -65,6 +65,7 @@ const electronAPI = isElectron
       setConfigPath: (path) => window.electronAPI.setConfigPath(path),
       getDocumentsPath: () => window.electronAPI.getDocumentsPath(),
       setDocumentsPath: (path) => window.electronAPI.setDocumentsPath(path),
+      getDefaultPaths: () => window.electronAPI.getDefaultPaths(),
       getMissingPaths: () => window.electronAPI.getMissingPaths(),
       getContainerLogs: (containerId) => window.electronAPI.getContainerLogs(containerId),
       stopContainer: (containerId) => window.electronAPI.stopContainer(containerId),
@@ -203,6 +204,7 @@ const httpAPI = {
   setConfigPath: async (path) => httpDispatch('/api/set-config-path', 'POST', { path }),
   getDocumentsPath: async () => httpDispatch('/api/get-documents-path', 'POST', {}),
   setDocumentsPath: async (path) => httpDispatch('/api/set-documents-path', 'POST', { path }),
+  getDefaultPaths: async () => httpDispatch('/api/get-default-paths', 'POST', {}),
   getMissingPaths: async () => httpDispatch('/api/get-missing-paths', 'POST', {}),
   getContainerLogs: async (containerId) =>
     httpDispatch('/api/get-container-logs', 'POST', { containerId }),


### PR DESCRIPTION
- Add 'createDirectory' to native Electron folder dialogs for New Folder button
- Add /api/fs-mkdir endpoint and New Folder icon button in web file browser
- Replace window.prompt() with MUI dialog for folder name input; show error on failure
- Add Defaults button to Welcome dialog that resets to default config/documents paths
- Move View Details button to left of Open Reports and use outlined variant

Resolves #229 