### PR TITLE
Fix restart workflow: clean instance folder, unique run names

### DIFF
--- a/src/main/collection.ts
+++ b/src/main/collection.ts
@@ -179,8 +179,21 @@ class WorkflowInstance implements IWorkflowInstance {
   }
 
   async getProgress(): Promise<Record<string, any>> {
-    // Read .nextflow.log and parse
-    const logFile = path.join(this.path, '.nextflow.log');
+    // Read the most recent .nextflow.log (handles rotation: .nextflow.log, .nextflow.log.1, ...)
+    let logFile = path.join(this.path, '.nextflow.log');
+    if (fs.existsSync(this.path)) {
+      const candidates = fs
+        .readdirSync(this.path)
+        .filter((f) => f.startsWith('.nextflow.log'))
+        .map((f) => ({
+          name: f,
+          mtime: fs.statSync(path.join(this.path, f)).mtimeMs
+        }))
+        .sort((a, b) => b.mtime - a.mtime);
+      if (candidates.length > 0) {
+        logFile = path.join(this.path, candidates[0].name);
+      }
+    }
     if (fs.existsSync(logFile)) {
       return await parseNextflowLog(logFile);
     } else {
@@ -243,7 +256,7 @@ class WorkflowInstance implements IWorkflowInstance {
 
   private _cachedProgress: Record<string, any> | null = null;
 
-  setCachedProgress(data: Record<string, any>) {
+  setCachedProgress(data: Record<string, any> | null) {
     this._cachedProgress = data;
   }
 }
@@ -711,7 +724,7 @@ export class Collection {
     if (!local_instance) {
       throw new Error(`Instance ${instance.id} not found in collection.`);
     }
-    const filename = path.join(local_instance.path, 'params.json');
+    const filename = path.join(local_instance.path, 'glacier-params.json');
     if (!fs.existsSync(filename)) {
       console.log(`Params file ${filename} does not exist.`);
       return {};
@@ -879,8 +892,16 @@ export class Collection {
     if (!local_instance) {
       throw new Error(`Instance ${instance.id} not found in collection.`);
     }
+    if (fs.existsSync(local_instance.path)) {
+      const entries = fs.readdirSync(local_instance.path);
+      for (const entry of entries) {
+        if (entry === 'glacier-params.json') continue;
+        fs.rmSync(path.join(local_instance.path, entry), { recursive: true, force: true });
+      }
+    }
     local_instance.status = WorkflowStatus.Created;
     local_instance.processes = [];
+    local_instance.setCachedProgress(null);
   }
 
   async killWorkflowInstance(instance: IWorkflowInstance): Promise<void> {

--- a/src/runners/nextflow/nextflow.ts
+++ b/src/runners/nextflow/nextflow.ts
@@ -98,7 +98,9 @@ export async function runWorkflow(
   const { is_electron, java_binary, jar_file, env } = await get_electron_paths();
 
   // Launch nextflow natively on host system
-  const name = instance.name;
+  // Append a timestamp suffix so each run has a unique Nextflow name (avoids
+  // "Run name <name> has been already used" collisions across restarts).
+  const name = `${instance.name}-${Date.now().toString(36)}`;
   const instancePath = instance.path; // launch from Windows path (on win32)
   const workPath = resolvePath(instancePath, 'work');
   await fs.mkdir(workPath, { recursive: true });
@@ -111,7 +113,7 @@ export async function runWorkflow(
   }
 
   // Save parameters to a file in the instance folder
-  const paramsFile = path.resolve(instancePath, 'params.json');
+  const paramsFile = path.resolve(instancePath, 'glacier-params.json');
   if (!resume && !restart) {
     fs.writeFile(paramsFile, JSON.stringify(params, null, 2), 'utf8');
   }

--- a/tests/unit/collection.test.js
+++ b/tests/unit/collection.test.js
@@ -347,10 +347,10 @@ describe('Collection', () => {
   });
 
   describe('getWorkflowInstanceParams', () => {
-    it('reads params.json from instance path', async () => {
+    it('reads glacier-params.json from instance path', async () => {
       const instPath = path.join(tmpDir, 'instances', 'test-instance');
       fs.mkdirSync(instPath, { recursive: true });
-      fs.writeFileSync(path.join(instPath, 'params.json'), JSON.stringify({ key: 'val' }), 'utf8');
+      fs.writeFileSync(path.join(instPath, 'glacier-params.json'), JSON.stringify({ key: 'val' }), 'utf8');
       const instance = { id: 'test', name: 'test', workflow_version: {}, path: instPath, processes: [], status: 'created' };
       collection.workflow_instances = [instance];
 
@@ -359,7 +359,7 @@ describe('Collection', () => {
       expect(params).toEqual({ key: 'val' });
     });
 
-    it('returns empty object if params.json missing', async () => {
+    it('returns empty object if glacier-params.json missing', async () => {
       const instance = { id: 'test', name: 'test', workflow_version: {}, path: '/nonexistent', processes: [], status: 'created' };
       collection.workflow_instances = [instance];
 

--- a/tests/unit/nextflow.test.js
+++ b/tests/unit/nextflow.test.js
@@ -190,7 +190,7 @@ describe('nextflow', () => {
           '-params-file',
           expect.any(String),
           '-name',
-          'test-name'
+          expect.stringMatching(/^test-name-/)
         ]),
         expect.objectContaining({
           cwd: '/tmp/instances/test',
@@ -398,19 +398,19 @@ describe('nextflow', () => {
   });
 
   describe('runWorkflow — params handling', () => {
-    it('writes params to params.json', async () => {
+    it('writes params to glacier-params.json', async () => {
       const writeSpy = vi.spyOn(fs.promises, 'writeFile').mockResolvedValue(undefined);
 
       await runWorkflow(makeInstance(), { key: 'value', num: 42 });
 
       expect(writeSpy).toHaveBeenCalledWith(
-        expect.stringContaining('params.json'),
+        expect.stringContaining('glacier-params.json'),
         JSON.stringify({ key: 'value', num: 42 }, null, 2),
         'utf8'
       );
     });
 
-    it('skips writing params.json on resume', async () => {
+    it('skips writing glacier-params.json on resume', async () => {
       const writeSpy = vi.spyOn(fs.promises, 'writeFile').mockResolvedValue(undefined);
 
       await runWorkflow(makeInstance(), {}, { resume: true });


### PR DESCRIPTION
- Delete all instance folder contents except glacier-params.json on restart
- Generate unique Nextflow run name (timestamp suffix) to avoid name collision
- Read most recent .nextflow.log* by mtime to handle log rotation
- Rename params.json to glacier-params.json to avoid pipeline name clash

Resolves #232 