### PR TITLE
Filter non-directory entries in parseCatalogues

### DIFF
--- a/src/main/collection.ts
+++ b/src/main/collection.ts
@@ -1422,9 +1422,11 @@ export class Collection {
     const owners = fs.readdirSync(this.catalogues_path);
     for (const owner of owners) {
       const ownerPath = path.join(this.catalogues_path, owner);
+      if (!fs.statSync(ownerPath).isDirectory()) continue;
       const repoDirs = fs.readdirSync(ownerPath);
       for (const repo of repoDirs) {
         const repoPath = path.join(ownerPath, repo);
+        if (!fs.statSync(repoPath).isDirectory()) continue;
         // Read catalogue.json
         const cat_file = path.join(repoPath, 'catalogue.json');
         const cat_contents = fs.readFileSync(cat_file, 'utf-8');

--- a/tests/unit/collection.test.js
+++ b/tests/unit/collection.test.js
@@ -675,6 +675,63 @@ describe('Collection', () => {
 
       expect(collection.catalogues).toEqual([]);
     });
+
+    it('skips non-directory entries at top level (e.g. .DS_Store alongside owner dirs)', async () => {
+      const catDir = path.join(tmpDir, 'catalogues', 'owner', 'cat-repo');
+      fs.mkdirSync(catDir, { recursive: true });
+      fs.writeFileSync(
+        path.join(catDir, 'catalogue.json'),
+        JSON.stringify({ name: 'Test Cat', sections: [] }),
+        'utf8'
+      );
+      fs.writeFileSync(path.join(tmpDir, 'catalogues', '.DS_Store'), '', 'utf8');
+
+      await collection.parseCatalogues();
+
+      expect(collection.catalogues).toHaveLength(1);
+      expect(collection.catalogues[0].name).toBe('Test Cat');
+      expect(collection.catalogues[0].source).toBe('owner/cat-repo');
+    });
+
+    it('skips non-directory entries at owner level (e.g. .DS_Store alongside repo dirs)', async () => {
+      const catDir = path.join(tmpDir, 'catalogues', 'owner', 'cat-repo');
+      fs.mkdirSync(catDir, { recursive: true });
+      fs.writeFileSync(
+        path.join(catDir, 'catalogue.json'),
+        JSON.stringify({ name: 'Test Cat', sections: [] }),
+        'utf8'
+      );
+      fs.writeFileSync(path.join(tmpDir, 'catalogues', 'owner', '.DS_Store'), '', 'utf8');
+
+      await collection.parseCatalogues();
+
+      expect(collection.catalogues).toHaveLength(1);
+      expect(collection.catalogues[0].name).toBe('Test Cat');
+    });
+
+    it('skips non-directory entries at all levels alongside valid catalogues', async () => {
+      const catDir = path.join(tmpDir, 'catalogues', 'owner', 'cat-repo');
+      fs.mkdirSync(catDir, { recursive: true });
+      fs.writeFileSync(
+        path.join(catDir, 'catalogue.json'),
+        JSON.stringify({ name: 'Test Cat', sections: [] }),
+        'utf8'
+      );
+      fs.writeFileSync(path.join(tmpDir, 'catalogues', '.DS_Store'), '', 'utf8');
+      fs.writeFileSync(path.join(tmpDir, 'catalogues', 'owner', '.DS_Store'), '', 'utf8');
+      fs.writeFileSync(path.join(catDir, '.DS_Store'), '', 'utf8');
+      const anotherDir = path.join(tmpDir, 'catalogues', 'anotherOwner', 'another-repo');
+      fs.mkdirSync(anotherDir, { recursive: true });
+      fs.writeFileSync(
+        path.join(anotherDir, 'catalogue.json'),
+        JSON.stringify({ name: 'Another Cat', sections: [] }),
+        'utf8'
+      );
+
+      await collection.parseCatalogues();
+
+      expect(collection.catalogues).toHaveLength(2);
+    });
   });
 
   describe('addCatalogue', () => {


### PR DESCRIPTION
Add isDirectory() guards to parseCatalogues() matching the pattern already used by parseWorkflows() and parseInstances(), preventing crashes when non-catalogue files like .DS_Store are present.

Add unit tests covering non-directory entries at top, owner, and repo levels alongside valid catalogues.

Resolves #244 