### PR TITLE
Beautify catalogue JSON parse errors into a results dialog

### DIFF
--- a/api-server/index.js
+++ b/api-server/index.js
@@ -315,6 +315,10 @@ app.post('/api/get-catalogues', async (req, res) =>
   post_response(res, call(collection.getCatalogues.bind(collection)))
 );
 
+app.post('/api/get-catalogue-parse-results', async (req, res) =>
+  post_response(res, call(collection.getCatalogueParseResults.bind(collection)))
+);
+
 app.post('/api/refresh-catalogues', async (req, res) =>
   post_response(res, call(collection.refreshCatalogues.bind(collection)))
 );

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -2,7 +2,9 @@
   "glacier": "GLACIER",
   "container-started": "Container built and started with ID",
   "error": {
-    "parsing-catalogue": "Error parsing catalogue"
+    "parsing-catalogue": "Catalogue loading results",
+    "catalogue-parse-success": "{{source}} loaded successfully",
+    "catalogue-parse-failure": "{{source}} — {{error}}"
   },
   "common": {
     "okay": "Okay",

--- a/src/main/collection.ts
+++ b/src/main/collection.ts
@@ -60,6 +60,11 @@ export interface CatalogueSection {
   hidden?: boolean;
 }
 
+export interface CatalogueParseError {
+  source: string;
+  error: string;
+}
+
 export interface CatalogueWorkflow {
   name: string;
   repo: string;
@@ -316,6 +321,7 @@ export class Collection {
   starting_up: boolean = true;
 
   catalogues: Catalogue[] = [];
+  catalogueParseErrors: CatalogueParseError[] = [];
   workflows: Workflow[] = [];
   workflow_instances: WorkflowInstance[] = [];
 
@@ -1438,10 +1444,9 @@ export class Collection {
   }
 
   async parseCatalogues() {
-    // Clear existing catalogues
     this.catalogues = [];
+    this.catalogueParseErrors = [];
 
-    // Read catalogues from catalogues path
     if (!fs.existsSync(this.catalogues_path)) {
       console.log(`Catalogues path ${this.catalogues_path} does not exist.`);
       return;
@@ -1454,18 +1459,30 @@ export class Collection {
       for (const repo of repoDirs) {
         const repoPath = path.join(ownerPath, repo);
         if (!fs.statSync(repoPath).isDirectory()) continue;
-        // Read catalogue.json
+
         const cat_file = path.join(repoPath, 'catalogue.json');
-        const cat_contents = fs.readFileSync(cat_file, 'utf-8');
-        let js = JSON.parse('{}');
+        let cat_contents: string;
+        try {
+          cat_contents = fs.readFileSync(cat_file, 'utf-8');
+        } catch (err) {
+          this.catalogueParseErrors.push({
+            source: `${owner}/${repo}`,
+            error: `Failed to read catalogue.json: ${err}`
+          });
+          continue;
+        }
+        let js: any;
         try {
           js = JSON.parse(cat_contents);
         } catch (err) {
-          throw new Error(`Failed to parse catalogue.json for ${owner}/${repo}: ${err}`);
+          this.catalogueParseErrors.push({
+            source: `${owner}/${repo}`,
+            error: `Failed to parse catalogue.json: ${err}`
+          });
+          continue;
         }
         js['source'] = `${owner}/${repo}`;
         js['base_dir'] = repoPath;
-        // Resolve scheme_url if provided
         if (js['scheme_url']) {
           try {
             const response = await fetch(js['scheme_url']);
@@ -1477,7 +1494,6 @@ export class Collection {
             console.error(`Failed to fetch scheme from ${js['scheme_url']}: ${err}`);
           }
         }
-        // Add to catalogues
         this.catalogues.push(js);
       }
     }
@@ -1938,6 +1954,17 @@ export class Collection {
   async getRepoTags(url: string): Promise<string[]> {
     const tags = await getRepoTags(url);
     return tags || [];
+  }
+
+  async getCatalogueParseResults() {
+    const results: { source: string; success: boolean; error?: string }[] = [];
+    for (const cat of this.catalogues) {
+      results.push({ source: cat.source, success: true });
+    }
+    for (const err of this.catalogueParseErrors) {
+      results.push({ source: err.source, success: false, error: err.error });
+    }
+    return results;
   }
 
   async getCatalogues() {

--- a/src/main/ipc-handlers.ts
+++ b/src/main/ipc-handlers.ts
@@ -22,6 +22,7 @@ export function registerIpcHandlers() {
     init: collection.init.bind(collection),
     'run-workflow': collection.runWorkflow.bind(collection),
     'get-catalogues': collection.getCatalogues.bind(collection),
+    'get-catalogue-parse-results': collection.getCatalogueParseResults.bind(collection),
     'refresh-catalogues': collection.refreshCatalogues.bind(collection),
     'add-catalogue': collection.addCatalogue.bind(collection),
     'remove-catalogue': collection.removeCatalogue.bind(collection),

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -74,6 +74,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
   showCatalogueSections: (catalogue_name: string) =>
     ipcRenderer.invoke('show-catalogue-sections', catalogue_name),
   getCatalogues: () => ipcRenderer.invoke('get-catalogues'),
+  getCatalogueParseResults: () => ipcRenderer.invoke('get-catalogue-parse-results'),
   refreshCatalogues: () => ipcRenderer.invoke('refresh-catalogues'),
   addUserWorkflow: (name: string, repoUrl: string, version: string, section: string) =>
     ipcRenderer.invoke('add-user-workflow', name, repoUrl, version, section),

--- a/src/renderer/pages/Main.tsx
+++ b/src/renderer/pages/Main.tsx
@@ -20,6 +20,8 @@ import { Panel, PanelGroup, PanelResizeHandle } from 'react-resizable-panels';
 import LibraryIcon from '@mui/icons-material/Apps';
 import InstancesIcon from '@mui/icons-material/Storage';
 import SettingsIcon from '@mui/icons-material/Settings';
+import CheckCircleIcon from '@mui/icons-material/CheckCircle';
+import CancelIcon from '@mui/icons-material/Cancel';
 import ListItemIcon from '@mui/material/ListItemIcon';
 import ListItemButton from '@mui/material/ListItemButton';
 import { useTranslation } from 'react-i18next';
@@ -56,6 +58,8 @@ export default function MainPage({ darkMode, setDarkMode }) {
   const [open, setOpen] = useState(false);
   const [item, setItem] = useState('');
   const [navigateToSettingsPage, setNavigateToSettingsPage] = useState('');
+  const [catalogueParseResults, setCatalogueParseResults] = useState([]);
+  const [showCatalogueParseErrors, setShowCatalogueParseErrors] = useState(false);
 
   const refreshInstancesList = async () => {
     API.listWorkflowInstances().then((result) => {
@@ -91,7 +95,15 @@ export default function MainPage({ darkMode, setDarkMode }) {
       });
       const r = await API.init();
       if (!r.ok) {
-        alert(t('error.parsing-catalogue') + ': ' + r.error.message);
+        console.error('Init failed:', r.error.message);
+      }
+      const parseResults = await API.getCatalogueParseResults();
+      if (parseResults.ok) {
+        const failures = parseResults.data.filter((res) => !res.success);
+        if (failures.length > 0) {
+          setCatalogueParseResults(parseResults.data);
+          setShowCatalogueParseErrors(true);
+        }
       }
       const pathResult = await API.getCollectionsPath();
       if (pathResult.ok) setCollectionsPath(pathResult.data);
@@ -157,9 +169,14 @@ export default function MainPage({ darkMode, setDarkMode }) {
     setCollectionsPath(pendingConfigPath);
     setDocumentsPath(pendingDocumentsPath);
     setShowPathDialog(false);
-    const r = await API.init();
-    if (!r.ok) {
-      alert(t('error.parsing-catalogue') + ': ' + r.error.message);
+    await API.init();
+    const parseResults = await API.getCatalogueParseResults();
+    if (parseResults.ok) {
+      const failures = parseResults.data.filter((res) => !res.success);
+      if (failures.length > 0) {
+        setCatalogueParseResults(parseResults.data);
+        setShowCatalogueParseErrors(true);
+      }
     }
     const pathResult = await API.getCollectionsPath();
     if (pathResult.ok) setCollectionsPath(pathResult.data);
@@ -377,6 +394,46 @@ export default function MainPage({ darkMode, setDarkMode }) {
           <Button onClick={handleDefaults}>{t('setup.defaults', 'Defaults')}</Button>
           <Button variant="contained" onClick={handleConfirmPaths} id="setup-continue-button">
             {t('setup.continue', 'Continue')}
+          </Button>
+        </DialogActions>
+      </Dialog>
+
+      <Dialog
+        open={showCatalogueParseErrors}
+        onClose={() => setShowCatalogueParseErrors(false)}
+        maxWidth="sm"
+        fullWidth
+      >
+        <DialogTitle>{t('error.parsing-catalogue')}</DialogTitle>
+        <DialogContent>
+          <List dense>
+            {catalogueParseResults.map((result, index) => (
+              <ListItem key={index}>
+                <ListItemIcon>
+                  {result.success ? (
+                    <CheckCircleIcon color="success" />
+                  ) : (
+                    <CancelIcon color="error" />
+                  )}
+                </ListItemIcon>
+                <ListItemText
+                  primary={result.source}
+                  secondary={
+                    result.success
+                      ? t('error.catalogue-parse-success', { source: result.source })
+                      : t('error.catalogue-parse-failure', {
+                          source: result.source,
+                          error: result.error
+                        })
+                  }
+                />
+              </ListItem>
+            ))}
+          </List>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setShowCatalogueParseErrors(false)} variant="contained">
+            {t('common.close')}
           </Button>
         </DialogActions>
       </Dialog>

--- a/src/renderer/services/api.ts
+++ b/src/renderer/services/api.ts
@@ -56,6 +56,7 @@ const electronAPI = isElectron
       showCatalogueSections: (catalogue_name) =>
         window.electronAPI.showCatalogueSections(catalogue_name),
       getCatalogues: () => window.electronAPI.getCatalogues(),
+      getCatalogueParseResults: () => window.electronAPI.getCatalogueParseResults(),
       refreshCatalogues: () => window.electronAPI.refreshCatalogues(),
       addUserWorkflow: (name, repoUrl, ver, section) =>
         window.electronAPI.addUserWorkflow(name, repoUrl, ver, section),
@@ -197,6 +198,7 @@ const httpAPI = {
   showCatalogueSections: async (catalogue_name) =>
     httpDispatch('/api/show-catalogue-sections', 'POST', { catalogue_name }),
   getCatalogues: async () => httpDispatch('/api/get-catalogues', 'POST', {}),
+  getCatalogueParseResults: async () => httpDispatch('/api/get-catalogue-parse-results', 'POST', {}),
   refreshCatalogues: async () => httpDispatch('/api/refresh-catalogues', 'POST', {}),
   addUserWorkflow: async (name, repoUrl, ver, section) =>
     httpDispatch('/api/add-user-workflow', 'POST', { name, repoUrl, ver, section }),

--- a/tests/unit/collection.test.js
+++ b/tests/unit/collection.test.js
@@ -742,6 +742,76 @@ describe('Collection', () => {
 
       expect(collection.catalogues).toHaveLength(2);
     });
+
+    it('collects errors for malformed catalogue.json instead of throwing', async () => {
+      const catDir = path.join(tmpDir, 'catalogues', 'owner', 'cat-repo');
+      fs.mkdirSync(catDir, { recursive: true });
+      fs.writeFileSync(path.join(catDir, 'catalogue.json'), '{invalid json}', 'utf8');
+
+      await collection.parseCatalogues();
+
+      expect(collection.catalogues).toHaveLength(0);
+      expect(collection.catalogueParseErrors).toHaveLength(1);
+      expect(collection.catalogueParseErrors[0].source).toBe('owner/cat-repo');
+      expect(collection.catalogueParseErrors[0].error).toContain('Failed to parse catalogue.json');
+    });
+
+    it('collects errors for unreadable catalogue.json', async () => {
+      const catDir = path.join(tmpDir, 'catalogues', 'owner', 'cat-repo');
+      fs.mkdirSync(catDir, { recursive: true });
+
+      await collection.parseCatalogues();
+
+      expect(collection.catalogues).toHaveLength(0);
+      expect(collection.catalogueParseErrors).toHaveLength(1);
+      expect(collection.catalogueParseErrors[0].source).toBe('owner/cat-repo');
+      expect(collection.catalogueParseErrors[0].error).toContain('Failed to read catalogue.json');
+    });
+
+    it('parses valid catalogues even when others have errors', async () => {
+      const goodDir = path.join(tmpDir, 'catalogues', 'owner', 'good-repo');
+      fs.mkdirSync(goodDir, { recursive: true });
+      fs.writeFileSync(
+        path.join(goodDir, 'catalogue.json'),
+        JSON.stringify({ name: 'Good Cat', sections: [] }),
+        'utf8'
+      );
+      const badDir = path.join(tmpDir, 'catalogues', 'owner', 'bad-repo');
+      fs.mkdirSync(badDir, { recursive: true });
+      fs.writeFileSync(path.join(badDir, 'catalogue.json'), '{invalid}', 'utf8');
+
+      await collection.parseCatalogues();
+
+      expect(collection.catalogues).toHaveLength(1);
+      expect(collection.catalogues[0].name).toBe('Good Cat');
+      expect(collection.catalogueParseErrors).toHaveLength(1);
+      expect(collection.catalogueParseErrors[0].source).toBe('owner/bad-repo');
+    });
+
+    it('getCatalogueParseResults returns combined successes and failures', async () => {
+      const goodDir = path.join(tmpDir, 'catalogues', 'owner', 'good-repo');
+      fs.mkdirSync(goodDir, { recursive: true });
+      fs.writeFileSync(
+        path.join(goodDir, 'catalogue.json'),
+        JSON.stringify({ name: 'Good Cat', sections: [] }),
+        'utf8'
+      );
+      const badDir = path.join(tmpDir, 'catalogues', 'owner', 'bad-repo');
+      fs.mkdirSync(badDir, { recursive: true });
+      fs.writeFileSync(path.join(badDir, 'catalogue.json'), '{invalid}', 'utf8');
+
+      await collection.parseCatalogues();
+      const results = await collection.getCatalogueParseResults();
+
+      expect(results).toHaveLength(2);
+      const success = results.find((r) => r.source === 'owner/good-repo');
+      expect(success).toBeDefined();
+      expect(success.success).toBe(true);
+      const failure = results.find((r) => r.source === 'owner/bad-repo');
+      expect(failure).toBeDefined();
+      expect(failure.success).toBe(false);
+      expect(failure.error).toContain('Failed to parse catalogue.json');
+    });
   });
 
   describe('addCatalogue', () => {


### PR DESCRIPTION
- parseCatalogues() now catches per-catalogue JSON errors instead of throwing, collecting errors in catalogueParseErrors[]
- Added getCatalogueParseResults() returning combined success/failure results to the frontend
- Replaced native alert() with a MUI Dialog showing green CheckCircle icons (success) and red Cancel icons (failure) with error details
- Dialog only appears when there are parse failures; close button dismisses it and the app continues with valid catalogues
- Added IPC handler, preload bridge, HTTP endpoint, and API method
- Added 5 unit tests covering error collection and results reporting

Resolves #241 