### PR TITLE
Align custom parameter components with MUI; standard help text; address spacing

### DIFF
--- a/src/renderer/pages/Parameters/FilePathControl.tsx
+++ b/src/renderer/pages/Parameters/FilePathControl.tsx
@@ -1,12 +1,26 @@
 // FilePathControl.tsx
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import { withJsonFormsControlProps } from '@jsonforms/react';
 import { ControlProps, isDescriptionHidden } from '@jsonforms/core';
-import { TextField, IconButton, Stack } from '@mui/material';
+import {
+  FormControl,
+  InputLabel,
+  OutlinedInput,
+  IconButton,
+  Stack,
+  FormHelperText
+} from '@mui/material';
 import { Box } from '@mui/system';
 import FileOpenIcon from '@mui/icons-material/FileOpen';
 import FolderOpenIcon from '@mui/icons-material/FolderOpen';
 import { API } from '../../services/api.js';
+
+function useFocus(): [boolean, () => void, () => void] {
+  const [focused, setFocused] = useState(false);
+  const onFocus = useCallback(() => setFocused(true), []);
+  const onBlur = useCallback(() => setFocused(false), []);
+  return [focused, onFocus, onBlur];
+}
 
 const toFilters = (accept?: string): Electron.FileFilter[] | undefined => {
   // accept like ".csv,.fastq,.fastq.gz,application/json"
@@ -32,6 +46,7 @@ function InnerFilePathControl(props: ControlProps) {
     handleChange,
     path,
     label,
+    description,
     required,
     visible = true,
     enabled = true,
@@ -44,10 +59,23 @@ function InnerFilePathControl(props: ControlProps) {
 
   if (!visible) return null;
 
-  const description =
-    (uischema as any)?.options?.description ?? schema?.description ?? (schema as any)?.help_text;
-
-  const showDesc = !isDescriptionHidden(visible, description, config);
+  const [focused, onFocus, onBlur] = useFocus();
+  const isValid = errors.length === 0;
+  const appliedUiSchemaOptions = { ...(config as any), ...(uischema as any)?.options };
+  const showUnfocusedDescription = appliedUiSchemaOptions.showUnfocusedDescription;
+  const hideRequiredAsterisk = appliedUiSchemaOptions.hideRequiredAsterisk;
+  const showDescription = !isDescriptionHidden(
+    visible,
+    description,
+    focused,
+    showUnfocusedDescription
+  );
+  const firstFormHelperText = showDescription
+    ? description
+    : !isValid
+    ? errors
+    : null;
+  const secondFormHelperText = showDescription && !isValid ? errors : null;
 
   type PickerMode = 'file' | 'directory' | 'both';
 
@@ -90,35 +118,52 @@ function InnerFilePathControl(props: ControlProps) {
   };
 
   return (
-    <Stack
-      direction="row"
-      spacing={1}
-      sx={{ opacity: enabled ? 1 : 0.6 }}
-      alignItems="flex-start" // top-align the children
+    <FormControl
+      size="small"
+      error={!isValid}
+      disabled={!enabled}
+      required={required}
+      onFocus={onFocus}
+      onBlur={onBlur}
+      id={id}
+      fullWidth
     >
-      {/* Left: field + helper text */}
-      <Box sx={{ flexGrow: 1 }}>
-        <TextField
-          id={id}
-          label={label}
-          value={data ?? ''}
-          required={required}
-          InputProps={{ readOnly: true }}
-          disabled={!enabled}
-          error={Boolean(errors)}
-          helperText={errors || (showDesc ? description : undefined)}
-          size="small"
-          fullWidth
-        />
-      </Box>
-
-      {/* Right: icon, top-aligned with the field */}
-      <Box sx={{ display: 'flex', alignItems: 'flex-start' }}>
-        <IconButton onClick={pick} disabled={!enabled}>
-          {picker === 'directory' ? <FolderOpenIcon /> : <FileOpenIcon />}
-        </IconButton>
-      </Box>
-    </Stack>
+      <InputLabel
+        htmlFor={`${id}-input`}
+        error={!isValid}
+        required={required && !hideRequiredAsterisk}
+      >
+        {label}
+      </InputLabel>
+      <Stack
+        direction="row"
+        spacing={1}
+        sx={{ opacity: enabled ? 1 : 0.6 }}
+        alignItems="flex-start"
+      >
+        <Box sx={{ flexGrow: 1 }}>
+          <OutlinedInput
+            id={`${id}-input`}
+            value={data ?? ''}
+            readOnly
+            label={label}
+            size="small"
+            fullWidth
+          />
+        </Box>
+        <Box sx={{ display: 'flex', alignItems: 'flex-start' }}>
+          <IconButton onClick={pick} disabled={!enabled}>
+            {picker === 'directory' ? <FolderOpenIcon /> : <FileOpenIcon />}
+          </IconButton>
+        </Box>
+      </Stack>
+      <FormHelperText error={!isValid && !showDescription}>
+        {firstFormHelperText}
+      </FormHelperText>
+      {secondFormHelperText && (
+        <FormHelperText error>{secondFormHelperText}</FormHelperText>
+      )}
+    </FormControl>
   );
 }
 

--- a/src/renderer/pages/Parameters/Parameters.tsx
+++ b/src/renderer/pages/Parameters/Parameters.tsx
@@ -324,7 +324,10 @@ export default function ParametersPage({
 
       <TabPanel value={tabSelected} index={2}>
         <Stack spacing={2} sx={{ mt: 1 }}>
-          <Paper variant="outlined" sx={{ p: 2, mb: 2 }}>
+          <Paper
+            variant="outlined"
+            sx={{ p: 2, mb: 2, '& .MuiCardContent-root > div > * + *': { mt: 1.5 } }}
+          >
             {!isEmpty(schema) ? (
               <JsonForms
                 schema={schema}

--- a/src/renderer/pages/Parameters/buildUISchema.ts
+++ b/src/renderer/pages/Parameters/buildUISchema.ts
@@ -11,6 +11,24 @@ export function buildUISchema(
 ): UISchemaElement {
   const showHidden = !!opts?.showHidden;
 
+  // Normalize help_text into description so all renderers (standard + custom)
+  // see the same text via ControlProps.description
+  function normalizeDescriptions(props: Record<string, any>) {
+    for (const k of Object.keys(props)) {
+      const p = props[k];
+      if (p && typeof p === 'object') {
+        p.description = p.description ?? p.help_text;
+      }
+    }
+  }
+  const defs = schema?.$defs || schema?.definitions || {};
+  for (const key of Object.keys(defs)) {
+    const def = defs[key];
+    if (def?.properties) normalizeDescriptions(def.properties);
+  }
+  normalizeDescriptions(schema?.properties ?? {});
+  normalizeDescriptions(schema?.['Launch settings'] ?? {});
+
   const categories = Object.entries(schema?.$defs || schema?.definitions || {})
     .map(([key, def]: [string, Record<string, any>]) => {
       let defKey = key.replace('#/definitions/', '');


### PR DESCRIPTION
- FilePathControl: replace TextField with FormControl+InputLabel+OutlinedInput to match MaterialInputControl structure exactly
- FilePathControl: add useFocus hook for correct isDescriptionHidden behavior
- FilePathControl: split helperText into two FormHelperText elements (description first, errors second) matching standard pattern
- buildUISchema: normalize help_text into schema.description so all renderers see the same text via ControlProps.description
- Parameters: add 12px spacing between adjacent controls within Group Cards to prevent overlapping helper text and labels

Resolves #117 #144 #192 