### PR TITLE
Add autoStoreDir setting for automatic store_dir parameter resolution

### DIFF
--- a/docs/settings.md
+++ b/docs/settings.md
@@ -58,6 +58,7 @@ Action buttons on this tab allow you to:
 |---------|-------------|
 | **Disable schema validation** | Bypass `nextflow_schema.json` validation when launching workflows. Use this if a workflow has a malformed schema. |
 | **Show hidden params** | Display parameters that the workflow schema marks as hidden. |
+| **Auto-resolve store_dir** | When creating an instance of a workflow that defines a `store_dir`, `storedir`, or `store-dir` parameter, automatically set it to `{documentsPath}/store_dir` and create the directory. The parameter is overwritten even if it carries a default from the schema. Note: this is a custom parameter convention, *not* Nextflow's built-in `storeDir` process directive. |
 
 ## Licenses
 

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -243,6 +243,7 @@
     "disable-projects": "Disable projects",
     "disable-schema-validation": "Disable strict schema validation",
     "show-hidden-params": "Show hidden parameters",
+    "auto-store-dir": "Auto-resolve store_dir parameter",
     "project-options": "Projects",
     "projects": {
       "url": "URL",

--- a/src/locales/fr/translation.json
+++ b/src/locales/fr/translation.json
@@ -233,6 +233,7 @@
     "disable-projects": "Désactiver la gestion des projets",
     "disable-schema-validation": "Désactiver la validation stricte du schéma",
     "show-hidden-params": "Afficher les paramètres cachés",
+    "auto-store-dir": "Résolution automatique du paramètre store_dir",
     "project-options": "Projets",
     "projects": {
       "url": "URL",

--- a/src/main/collection.ts
+++ b/src/main/collection.ts
@@ -282,6 +282,22 @@ function countProcesses(groups: any[]): { total: number; completed: number } {
   return { total: allProcesses.size, completed };
 }
 
+function findStoreDirKey(schema: Record<string, any>): string | null {
+  const storeDirKeys = ['store_dir', 'storedir', 'store-dir'];
+  const props = schema?.properties ?? {};
+  for (const key of storeDirKeys) {
+    if (key in props) return key;
+  }
+  const defs = schema?.$defs || schema?.definitions || {};
+  for (const defKey of Object.keys(defs)) {
+    const defProps = defs[defKey]?.properties ?? {};
+    for (const key of storeDirKeys) {
+      if (key in defProps) return key;
+    }
+  }
+  return null;
+}
+
 // Singleton class
 export class Collection {
   // --- Class management --------------------------------------------------------------
@@ -863,7 +879,7 @@ export class Collection {
     await this.parseCollection();
   }
 
-  createWorkflowInstance(workflow_id: string, version: string): IWorkflowInstance {
+  async createWorkflowInstance(workflow_id: string, version: string): Promise<IWorkflowInstance> {
     const { owner, repo } = parseRepoUrl(workflow_id);
     const workflow = this.workflows.find((wf) => wf.id === `${owner}/${repo}`);
     if (!workflow) {
@@ -885,6 +901,19 @@ export class Collection {
     const instance_id = instance_name;
     const instance_path = path.join(this.instances_path, owner, repo_and_version, instance_name);
     this.ensurePathExists(instance_path);
+
+    // Auto-set store_dir if the setting is enabled and the workflow schema has it
+    if (this.settingsGet('autoStoreDir')) {
+      const schema = await getWorkflowSchema(workflow_version.path);
+      const storeDirKey = findStoreDirKey(schema);
+      if (storeDirKey) {
+        const storeDirPath = path.join(getDocumentsPath(), 'store_dir');
+        const paramsFile = path.join(instance_path, 'glacier-params.json');
+        safeFs.writeFileSync(paramsFile, JSON.stringify({ [storeDirKey]: storeDirPath }, null, 2));
+        safeFs.mkdirSync(storeDirPath, { recursive: true });
+      }
+    }
+
     const instance = new WorkflowInstance({
       id: instance_id,
       name: instance_name,

--- a/src/main/store.ts
+++ b/src/main/store.ts
@@ -16,6 +16,7 @@ export interface StoreSchema {
   instanceSortBy: string;
   instanceSortDir: string;
   showLogPanel: boolean;
+  autoStoreDir: boolean;
 }
 
 let _instance: any = null;
@@ -37,7 +38,8 @@ function getInstance() {
           disableSchemaValidation: { type: 'boolean', default: false },
           instanceSortBy: { type: 'string', default: 'name' },
           instanceSortDir: { type: 'string', default: 'asc' },
-          showLogPanel: { type: 'boolean', default: false }
+          showLogPanel: { type: 'boolean', default: false },
+          autoStoreDir: { type: 'boolean', default: true }
         },
         name: 'config',
         projectName: 'GLACIER',

--- a/src/renderer/pages/Main.tsx
+++ b/src/renderer/pages/Main.tsx
@@ -55,6 +55,7 @@ export default function MainPage({ darkMode, setDarkMode }) {
   const [message, setMessage] = useState('');
   const [showHiddenParams, setShowHiddenParams] = useState(false);
   const [showLogPanel, setShowLogPanel] = useState(false);
+  const [autoStoreDir, setAutoStoreDir] = useState(false);
   const [open, setOpen] = useState(false);
   const [item, setItem] = useState('');
   const [navigateToSettingsPage, setNavigateToSettingsPage] = useState('');
@@ -92,6 +93,9 @@ export default function MainPage({ darkMode, setDarkMode }) {
       });
       API.settingsGet(SettingsKey.ShowLogPanel).then((result) => {
         if (result.ok) setShowLogPanel(result.data);
+      });
+      API.settingsGet(SettingsKey.AutoStoreDir).then((result) => {
+        if (result.ok) setAutoStoreDir(result.data);
       });
       const r = await API.init();
       if (!r.ok) {
@@ -315,6 +319,8 @@ export default function MainPage({ darkMode, setDarkMode }) {
                 setShowHiddenParams={setShowHiddenParams}
                 showLogPanel={showLogPanel}
                 onShowLogPanelChange={handleShowLogPanel}
+                autoStoreDir={autoStoreDir}
+                setAutoStoreDir={setAutoStoreDir}
                 navigateToPage={navigateToSettingsPage}
                 setNavigateToPage={setNavigateToSettingsPage}
                 onReopenSetup={() => {

--- a/src/renderer/pages/Parameters/Parameters.tsx
+++ b/src/renderer/pages/Parameters/Parameters.tsx
@@ -167,9 +167,6 @@ export default function ParametersPage({
       const paramsResult = await API.getWorkflowInstanceParams(instance);
       if (paramsResult.ok && paramsResult.data) {
         setParams(paramsResult.data);
-        if (Object.keys(paramsResult.data).length > 0) {
-          setTabSelected(2);
-        }
       }
     };
     const fetchReadme = async () => {

--- a/src/renderer/pages/Settings/Settings.tsx
+++ b/src/renderer/pages/Settings/Settings.tsx
@@ -36,13 +36,15 @@ export default function SettingsPage({
   setShowHiddenParams,
   showLogPanel,
   onShowLogPanelChange,
+  autoStoreDir,
+  setAutoStoreDir,
   navigateToPage,
   setNavigateToPage,
   onReopenSetup
 }) {
   const { t, i18n } = useTranslation();
 
-  const [language, setLanguage] = React.useState(i18n.language || 'en');
+  const [language, setLanguage] = React.useState(i18n.language?.split('-')[0] || 'en');
   const [tabValue, setTabValue] = React.useState(0);
   const [disableSchemaValidation, setDisableSchemaValidation] = React.useState(false);
 
@@ -90,6 +92,13 @@ export default function SettingsPage({
   const handleDisableSchemaValidation = (value) => {
     setDisableSchemaValidation(value);
     API.settingsSet(SettingsKey.DisableSchemaValidation, value).then((result) => {
+      if (!result.ok) console.error(result.error.message);
+    });
+  };
+
+  const handleAutoStoreDir = (value) => {
+    setAutoStoreDir(value);
+    API.settingsSet(SettingsKey.AutoStoreDir, value).then((result) => {
       if (!result.ok) console.error(result.error.message);
     });
   };
@@ -281,6 +290,15 @@ export default function SettingsPage({
               />
             }
             label={t('settings.show-hidden-params')}
+          />
+          <FormControlLabel
+            control={
+              <Switch
+                checked={autoStoreDir}
+                onChange={(_, checked) => handleAutoStoreDir(checked)}
+              />
+            }
+            label={t('settings.auto-store-dir')}
           />
         </Stack>
       </TabPanel>

--- a/src/types/settings.ts
+++ b/src/types/settings.ts
@@ -10,7 +10,8 @@ export const SettingsKey = {
   DisableSchemaValidation: 'disableSchemaValidation',
   InstanceSortBy: 'instanceSortBy',
   InstanceSortDir: 'instanceSortDir',
-  ShowLogPanel: 'showLogPanel'
+  ShowLogPanel: 'showLogPanel',
+  AutoStoreDir: 'autoStoreDir'
 } as const;
 
 export type SettingsKey = (typeof SettingsKey)[keyof typeof SettingsKey];

--- a/tests/unit/collection.test.js
+++ b/tests/unit/collection.test.js
@@ -209,12 +209,12 @@ describe('Collection', () => {
   });
 
   describe('createWorkflowInstance', () => {
-    it('creates a new instance and records it', () => {
+    it('creates a new instance and records it', async () => {
       const wf = makeWorkflow();
       collection.workflows = [wf];
       vi.mocked(repo.generateUniqueName).mockReturnValue('happy-fox');
 
-      const instance = collection.createWorkflowInstance('owner/repo', 'v1.0');
+      const instance = await collection.createWorkflowInstance('owner/repo', 'v1.0');
 
       expect(instance.name).toBe('happy-fox');
       expect(instance.workflow_version.version).toBe('v1.0');
@@ -222,15 +222,15 @@ describe('Collection', () => {
       expect(collection.workflow_instances[0]).toBe(instance);
     });
 
-    it('throws for unknown workflow', () => {
-      expect(() => collection.createWorkflowInstance('unknown/repo', 'v1.0')).toThrow(
+    it('throws for unknown workflow', async () => {
+      await expect(collection.createWorkflowInstance('unknown/repo', 'v1.0')).rejects.toThrow(
         'not found'
       );
     });
 
-    it('throws for workflow with no versions', () => {
+    it('throws for workflow with no versions', async () => {
       collection.workflows = [makeWorkflow({ versions: [] })];
-      expect(() => collection.createWorkflowInstance('owner/repo', 'v1.0')).toThrow(
+      await expect(collection.createWorkflowInstance('owner/repo', 'v1.0')).rejects.toThrow(
         'no versions'
       );
     });


### PR DESCRIPTION
- New boolean setting 'autoStoreDir' (default: true) in Advanced settings
- When enabled, auto-sets store_dir/storedir/store-dir parameter at instance creation to {documentsPath}/store_dir and creates the directory
- Schema check finds the parameter key in root properties or
- i18n keys for en/fr
- Documentation in docs/settings.md
- Fix language dropdown not showing current selection due to locale codes (e.g. en-US not matching en)

Resolves #214 