### PR TITLE
feat: parse Command error block from nextflow logs and display on progress screen

### DIFF
--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -248,7 +248,10 @@
       "hint-disk": "This error usually indicates the process ran out of disk space. Try freeing up storage or increasing the disk allocation.",
       "hint-timeout": "This error usually indicates the process exceeded the time limit. Try increasing the timeout or optimising the workflow.",
       "hint-permission": "This error usually indicates a permissions issue. Check file and directory permissions.",
-      "no-logs": "This log file is empty."
+      "no-logs": "This log file is empty.",
+      "command-error": "Command error",
+      "exit-status": "Exit status: {{code}}",
+      "oom-killed": "Process was killed (out of memory)"
     },
     "open-results-folder": "Open Results Folder"
   },

--- a/src/locales/fr/translation.json
+++ b/src/locales/fr/translation.json
@@ -236,7 +236,10 @@
       "open-in-editor": "Ouvrir dans l'éditeur",
       "loading": "Chargement du progrès...",
       "waiting-for-report": "Chargement du rapport...",
-      "no-logs": "Ce fichier journal est vide."
+      "no-logs": "Ce fichier journal est vide.",
+      "command-error": "Erreur de commande",
+      "exit-status": "Code de sortie : {{code}}",
+      "oom-killed": "Processus tué (mémoire insuffisante)"
     },
     "open-results-folder": "Ouvrir le dossier des résultats"
   },

--- a/src/renderer/pages/Monitor/ProgressTracker.tsx
+++ b/src/renderer/pages/Monitor/ProgressTracker.tsx
@@ -18,8 +18,12 @@ import { getDateLocale } from '../../../locales';
 import DoneIcon from '@mui/icons-material/Done';
 import CancelIcon from '@mui/icons-material/Cancel';
 import PendingIcon from '@mui/icons-material/Pending';
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
+import ExpandLessIcon from '@mui/icons-material/ExpandLess';
+import Collapse from '@mui/material/Collapse';
 import AnsiLog from './AnsiLog.js';
 import { findErrorHint } from './errorHints.js';
+import Chip from '@mui/material/Chip';
 
 const SECOND = 1000;
 
@@ -59,6 +63,8 @@ type TreeItemWithLabel = {
   status: ProcessStatus;
   progress: number;
   work_folder?: string;
+  exitStatus?: string;
+  commandError?: string;
 };
 
 interface CustomLabelProps {
@@ -70,6 +76,8 @@ interface CustomLabelProps {
   status: ProcessStatus;
   progress: number;
   work_folder?: string;
+  exitStatus?: string;
+  commandError?: string;
 }
 
 function CustomLabel({
@@ -80,13 +88,16 @@ function CustomLabel({
   logs_available,
   status,
   progress,
-  work_folder
+  work_folder,
+  exitStatus,
+  commandError
 }: CustomLabelProps) {
   const { t } = useTranslation();
   const [showLog, setShowLog] = useState(false);
   const [logText, setLogText] = useState('');
   const [anchorEl, setAnchorEl] = useState(null);
   const [logType, setLogType] = useState(log_types[0]);
+  const [showError, setShowError] = useState(true);
   const { logID, setLogID } = React.useContext(LogIDContext);
   const ctx = React.useContext(GetInstanceContext);
   const instance = ctx?.instance;
@@ -256,6 +267,74 @@ function CustomLabel({
           <AnsiLog text={logText} />
         </Box>
       )}
+
+      {/* Command error display — collapsible, expanded by default */}
+      {status === ProcessStatus.Error && commandError && (
+        <Box
+          sx={{
+            border: '1px solid #d32f2f',
+            borderRadius: '4px',
+            mt: 1,
+            width: '100%',
+            bgcolor: 'rgba(211, 47, 47, 0.04)'
+          }}
+        >
+          <Box
+            sx={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: 1,
+              p: 1.5,
+              pb: showError ? 0 : 1.5,
+              cursor: 'pointer',
+              userSelect: 'none'
+            }}
+            onClick={() => setShowError(!showError)}
+          >
+            <IconButton size="small" sx={{ p: 0 }}>
+              {showError ? <ExpandLessIcon fontSize="small" /> : <ExpandMoreIcon fontSize="small" />}
+            </IconButton>
+            <Typography variant="subtitle2" color="error">
+              {t('monitor.progress.command-error')}
+            </Typography>
+            {exitStatus === '137' && (
+              <Chip
+                label={t('monitor.progress.oom-killed')}
+                size="small"
+                color="error"
+                variant="outlined"
+              />
+            )}
+            {exitStatus && exitStatus !== '137' && (
+              <Chip
+                label={t('monitor.progress.exit-status', { code: exitStatus })}
+                size="small"
+                color="error"
+                variant="outlined"
+              />
+            )}
+          </Box>
+          <Collapse in={showError}>
+            <Box
+              component="pre"
+              sx={{
+                m: 0,
+                p: 1.5,
+                pt: 1,
+                bgcolor: 'rgba(0,0,0,0.06)',
+                borderRadius: '2px',
+                fontSize: '0.8rem',
+                whiteSpace: 'pre-wrap',
+                wordBreak: 'break-word',
+                maxHeight: '200px',
+                overflow: 'auto'
+              }}
+            >
+              {commandError}
+            </Box>
+          </Collapse>
+        </Box>
+      )}
     </Box>
   );
 }
@@ -279,7 +358,9 @@ const CustomTreeItem = React.forwardRef(function CustomTreeItem(
           logs_available: item?.logs_available,
           status: item?.status,
           progress: item?.progress,
-          work_folder: item?.work_folder
+          work_folder: item?.work_folder,
+          exitStatus: item?.exitStatus,
+          commandError: item?.commandError
         } as CustomLabelProps
       }}
     />
@@ -306,6 +387,23 @@ const FormatWorkflowStatus = ({ workflowStatus, isWorkflowRunning }: { workflowS
   );
 };
 
+const collectErrorPaths = (items: any[]): string[] => {
+  const ids = new Set<string>();
+  const walk = (nodes: any[], ancestorIds: string[]) => {
+    for (const node of nodes) {
+      const path = [...ancestorIds, node.id];
+      if (node.status === ProcessStatus.Error) {
+        path.forEach((id) => ids.add(id));
+      }
+      if (node.children?.length) {
+        walk(node.children, path);
+      }
+    }
+  };
+  walk(items, []);
+  return Array.from(ids);
+};
+
 const addGroup = (parent, group, itemIdRef) => {
   parent.push({
     id: String(itemIdRef.current++),
@@ -322,9 +420,14 @@ const addGroup = (parent, group, itemIdRef) => {
   group?.group.forEach((subgroup) => {
     addGroup(item.children, subgroup, itemIdRef);
   });
-  // Extract last process state
+  // Extract last process state and error details
   if (group?.process.length > 0) {
-    item.status = group.process[group.process.length - 1].status;
+    const lastProcess = group.process[group.process.length - 1];
+    item.status = lastProcess.status;
+    if (lastProcess.status === 'error') {
+      item.exitStatus = lastProcess.exitStatus;
+      item.commandError = lastProcess.commandError;
+    }
   }
   // Extract work folder
   const work_folders = group?.process.filter((process) => process.work !== undefined);
@@ -384,6 +487,7 @@ export default function ProgressTracker({ instance }) {
     WorkflowStatus.Undefined
   );
   const [items, setItems] = React.useState<any[]>([]);
+  const [expandedItems, setExpandedItems] = React.useState<string[]>([]);
   const [hintKey, setHintKey] = React.useState<string | undefined>(undefined);
   const [logID, setLogID] = React.useState<string>('');
   const itemIdRef = React.useRef(0);
@@ -439,6 +543,8 @@ export default function ProgressTracker({ instance }) {
         report?.group.forEach((group) => addGroup(items, group, itemIdRef));
         // Ascend leaf status to parent groups, and calculate progress
         items.forEach((group) => ascendStatus(group, isRunning));
+        // Auto-expand tree to show errored processes
+        setExpandedItems(collectErrorPaths(items));
         setItems(items);
       });
     };
@@ -463,7 +569,12 @@ export default function ProgressTracker({ instance }) {
           {items?.length > 0 ? (
             <LogIDContext.Provider value={{ logID, setLogID }}>
               <GetInstanceContext.Provider value={{ instance, isWorkflowRunning }}>
-                <RichTreeView items={items} slots={{ item: CustomTreeItem }} />
+                <RichTreeView
+                  items={items}
+                  slots={{ item: CustomTreeItem }}
+                  expandedItems={expandedItems}
+                  onExpandedItemsChange={setExpandedItems}
+                />
               </GetInstanceContext.Provider>
             </LogIDContext.Provider>
           ) : workflowStatus === WorkflowStatus.Failed ? (

--- a/src/runners/nextflow/nf-parse.ts
+++ b/src/runners/nextflow/nf-parse.ts
@@ -47,11 +47,42 @@ export async function readNextflowLog(path: string) {
     group: []
   };
 
-  for await (const line0 of rl) {
-    const line = line0.replace(/\x1b\[[0-9;]*m/g, ''); // strip ANSI color codes if present
+  const addProcess = (obj: any, key: string) => {
+    const process_hierarchy = key.split(':');
+    const last = process_hierarchy[process_hierarchy.length - 1];
+    const bracketMatch = last.match(/(.*)\s*\(([^)]+)\)/);
+    if (bracketMatch) {
+      process_hierarchy[process_hierarchy.length - 1] = bracketMatch[1].trim();
+      process_hierarchy.push(bracketMatch[2]);
+    }
+
+    for (const part of process_hierarchy) {
+      obj = obj['group'];
+      const obj_present = obj.find((o: any) => o.name === part);
+      if (obj_present) {
+        obj = obj_present;
+      } else {
+        obj.push({
+          name: part,
+          process: [],
+          group: []
+        });
+        obj = obj[obj.length - 1];
+      }
+    }
+    return obj;
+  };
+
+  const lines = rl[Symbol.asyncIterator]();
+  let nextResult = await lines.next();
+
+  while (!nextResult.done) {
+    const line0 = nextResult.value;
+    const line = line0.replace(/\x1b\[[0-9;]*m/g, '');
     const ts = line.split('[', 1)[0].trim();
 
     let matched = false;
+    let errorBlockParsed = false;
 
     for (const r of RES) {
       const m = r.re.exec(line);
@@ -61,40 +92,10 @@ export async function readNextflowLog(path: string) {
 
       const process_label = m[1];
 
-      // Strip trailing brackets from process names (e.g. "foo (2)" -> "foo")
       let process_group = '';
       if (process_label) {
-        // process_label can be empty for wf_done
         process_group = process_label.replace(/\s*\(.*\)$/, '');
       }
-
-      const addProcess = (obj: any, key: string) => {
-        // Convert key to a hierarchy
-        const process_hierarchy = key.split(':');
-        const last = process_hierarchy[process_hierarchy.length - 1];
-        const bracketMatch = last.match(/(.*)\s*\(([^)]+)\)/);
-        if (bracketMatch) {
-          process_hierarchy[process_hierarchy.length - 1] = bracketMatch[1].trim();
-          process_hierarchy.push(bracketMatch[2]);
-        }
-
-        // Traverse the hierarchy, creating objects as needed
-        for (const part of process_hierarchy) {
-          obj = obj['group'];
-          const obj_present = obj.find((o: any) => o.name === part);
-          if (obj_present) {
-            obj = obj_present;
-          } else {
-            obj.push({
-              name: part,
-              process: [],
-              group: []
-            });
-            obj = obj[obj.length - 1];
-          }
-        }
-        return obj;
-      };
 
       switch (r.t) {
         case 'created':
@@ -114,11 +115,9 @@ export async function readNextflowLog(path: string) {
         case 'submitted':
           let obj = addProcess(progress, m[2]);
 
-          // Duplicate submit jobs can exist with the same name - subset by work ID
           const old_process_label = obj.process.filter((p: any) => p.work !== undefined)[0]?.work;
           if (old_process_label && old_process_label !== process_label) {
             if (obj.group.length === 0) {
-              // Move old work entries to a subgroup by work ID
               obj.group.push({
                 name: old_process_label,
                 process: [],
@@ -139,7 +138,6 @@ export async function readNextflowLog(path: string) {
           }
 
           const last_update = await lastUpdateTime(root_path, process_label, 'log');
-          // m[1] = work ID, m[2] = process name — full_name must use process name
           const submitted_full_name = m[2].replace(/\s*\(.*\)$/, '');
           obj.process.push({
             time: ts,
@@ -157,13 +155,71 @@ export async function readNextflowLog(path: string) {
             status: 'completed'
           });
           break;
-        case 'error':
-          addProcess(progress, process_label).process.push({
+        case 'error': {
+          errorBlockParsed = true;
+
+          const entry: any = {
             time: ts,
             full_name: process_group,
             status: 'error'
-          });
+          };
+
+          let exitStatus: string | undefined;
+          let commandError: string[] = [];
+          let cause: string | undefined;
+          let inCommandError = false;
+          let pendingField: 'cause' | 'exitStatus' | null = null;
+
+          while (!(nextResult = await lines.next()).done) {
+            const raw = nextResult.value.replace(/\x1b\[[0-9;]*m/g, '');
+            const trimmed = raw.trim();
+            if (!trimmed) continue;
+
+            if (trimmed === 'Work dir:' || trimmed.startsWith('Work dir:')) break;
+
+            if (trimmed === 'Caused by:') {
+              pendingField = 'cause';
+              inCommandError = false;
+              continue;
+            }
+
+            if (trimmed === 'Command exit status:') {
+              pendingField = 'exitStatus';
+              inCommandError = false;
+              continue;
+            }
+
+            if (trimmed === 'Command error:' || trimmed === 'Command error (stderr):') {
+              pendingField = null;
+              inCommandError = true;
+              continue;
+            }
+
+            if (inCommandError) {
+              commandError.push(trimmed);
+              continue;
+            }
+
+            if (pendingField === 'cause' && !cause) {
+              cause = trimmed;
+              pendingField = null;
+              continue;
+            }
+
+            if (pendingField === 'exitStatus' && !exitStatus) {
+              exitStatus = trimmed;
+              pendingField = null;
+              continue;
+            }
+          }
+
+          if (exitStatus) entry.exitStatus = exitStatus;
+          if (cause) entry.cause = cause;
+          if (commandError.length > 0) entry.commandError = commandError.join('\n');
+
+          addProcess(progress, process_label).process.push(entry);
           break;
+        }
         case 'aborted':
           progress['workflow'].push({ time: ts, status: WorkflowStatus.Failed, cause: m[1] });
           break;
@@ -171,12 +227,15 @@ export async function readNextflowLog(path: string) {
           progress['workflow'].push({ time: ts, status: WorkflowStatus.Completed });
           break;
       }
-      break; // one event per line is enough
+      break;
     }
 
     if (!matched && DEBUG) {
-      // Helps debug when patterns miss a line you expected to match
       console.error('UNMATCHED:', line);
+    }
+
+    if (!errorBlockParsed) {
+      nextResult = await lines.next();
     }
   }
 

--- a/tests/unit/frontend/ProgressTrackerErrors.test.tsx
+++ b/tests/unit/frontend/ProgressTrackerErrors.test.tsx
@@ -141,3 +141,138 @@ describe('ProgressTracker — error hints', () => {
     expect(screen.queryByText(/^monitor\.progress\.hint-/)).not.toBeInTheDocument();
   });
 });
+
+describe('ProgressTracker — command error display', () => {
+  beforeEach(() => {
+    mockGetInstanceProgress.mockClear();
+  });
+
+  it('shows command error section for errored process', async () => {
+    const groupEntry = {
+      name: 'OOMER',
+      process: [
+        {
+          time: '12:00:00',
+          full_name: 'OOMER',
+          status: 'error',
+          exitStatus: '137',
+          commandError: 'Simulating out-of-memory error: process killed (exit code 137)',
+          cause: 'Process `OOMER` terminated with an error exit status (137)'
+        }
+      ],
+      group: []
+    };
+    mockGetInstanceProgress.mockResolvedValue({
+      ok: true,
+      data: makeProgress(
+        [
+          { time: '12:00:00', status: 'running' },
+          { time: '12:00:01', status: 'failed', cause: 'Process terminated' },
+          { time: '12:00:02', status: 'completed' }
+        ],
+        [groupEntry]
+      )
+    });
+
+    render(<ProgressTracker instance={mockInstance} />);
+
+    expect(
+      await screen.findByText('Simulating out-of-memory error: process killed (exit code 137)')
+    ).toBeInTheDocument();
+  });
+
+  it('shows OOM chip for exit code 137', async () => {
+    const groupEntry = {
+      name: 'OOMER',
+      process: [
+        {
+          time: '12:00:00',
+          full_name: 'OOMER',
+          status: 'error',
+          exitStatus: '137',
+          commandError: 'out of memory',
+          cause: 'Process terminated (137)'
+        }
+      ],
+      group: []
+    };
+    mockGetInstanceProgress.mockResolvedValue({
+      ok: true,
+      data: makeProgress(
+        [
+          { time: '12:00:00', status: 'running' },
+          { time: '12:00:01', status: 'failed' },
+          { time: '12:00:02', status: 'completed' }
+        ],
+        [groupEntry]
+      )
+    });
+
+    render(<ProgressTracker instance={mockInstance} />);
+
+    expect(await screen.findByText('monitor.progress.oom-killed')).toBeInTheDocument();
+  });
+
+  it('shows exit status chip for non-137 exit code', async () => {
+    const groupEntry = {
+      name: 'failing-proc',
+      process: [
+        {
+          time: '12:00:00',
+          full_name: 'failing-proc',
+          status: 'error',
+          exitStatus: '1',
+          commandError: 'generic error',
+          cause: 'Process terminated (1)'
+        }
+      ],
+      group: []
+    };
+    mockGetInstanceProgress.mockResolvedValue({
+      ok: true,
+      data: makeProgress(
+        [
+          { time: '12:00:00', status: 'running' },
+          { time: '12:00:01', status: 'failed' },
+          { time: '12:00:02', status: 'completed' }
+        ],
+        [groupEntry]
+      )
+    });
+
+    render(<ProgressTracker instance={mockInstance} />);
+
+    expect(
+      await screen.findByText('monitor.progress.exit-status')
+    ).toBeInTheDocument();
+  });
+
+  it('does not show command error section for completed process', async () => {
+    const groupEntry = {
+      name: 'success',
+      process: [
+        {
+          time: '12:00:00',
+          full_name: 'success',
+          status: 'completed'
+        }
+      ],
+      group: []
+    };
+    mockGetInstanceProgress.mockResolvedValue({
+      ok: true,
+      data: makeProgress(
+        [
+          { time: '12:00:00', status: 'running' },
+          { time: '12:00:01', status: 'completed' }
+        ],
+        [groupEntry]
+      )
+    });
+
+    render(<ProgressTracker instance={mockInstance} />);
+
+    await new Promise((r) => setTimeout(r, 100));
+    expect(screen.queryByText('monitor.progress.command-error')).not.toBeInTheDocument();
+  });
+});

--- a/tests/unit/nf-parse.test.js
+++ b/tests/unit/nf-parse.test.js
@@ -148,6 +148,131 @@ describe('nf-parse', () => {
       expect(result.group[0].name).toBe('foo');
       expect(result.group[0].process[0].status).toBe('error');
     });
+
+    it('parses exit status and command error from error block', async () => {
+      const content = [
+        "2024-01-01 12:00:00.123 Error executing process > 'OOMER'",
+        '',
+        'Caused by:',
+        "  Process `OOMER` terminated with an error exit status (137)",
+        '',
+        'Command executed:',
+        '  echo "Simulating out-of-memory error: process killed (exit code 137)"',
+        '  exit 137',
+        '',
+        'Command exit status:',
+        '  137',
+        '',
+        'Command output:',
+        '  Simulating out-of-memory error: process killed (exit code 137)',
+        '',
+        'Command error:',
+        '  Simulating out-of-memory error: process killed (exit code 137)',
+        '',
+        'Work dir:',
+        '  /path/to/work/dir',
+        '',
+        'Tip: view the complete command output by changing to the process work dir'
+      ].join('\n');
+      const logPath = createLogFile(content);
+      const result = await parseNextflowLog(logPath);
+
+      expect(result.group[0].name).toBe('OOMER');
+      expect(result.group[0].process).toHaveLength(1);
+      const entry = result.group[0].process[0];
+      expect(entry.status).toBe('error');
+      expect(entry.exitStatus).toBe('137');
+      expect(entry.commandError).toBe(
+        'Simulating out-of-memory error: process killed (exit code 137)'
+      );
+      expect(entry.cause).toBe(
+        'Process `OOMER` terminated with an error exit status (137)'
+      );
+    });
+
+    it('parses multi-line command error', async () => {
+      const content = [
+        "2024-01-01 12:00:00.123 Error executing process > 'test'",
+        '',
+        'Caused by:',
+        '  Process `test` terminated with an error exit status (1)',
+        '',
+        'Command exit status:',
+        '  1',
+        '',
+        'Command error:',
+        '  line 1: some error',
+        '  line 2: more details',
+        '  line 3: stack trace',
+        '',
+        'Work dir:',
+        '  /path/to/work/dir'
+      ].join('\n');
+      const logPath = createLogFile(content);
+      const result = await parseNextflowLog(logPath);
+
+      const entry = result.group[0].process[0];
+      expect(entry.exitStatus).toBe('1');
+      expect(entry.commandError).toBe(
+        'line 1: some error\nline 2: more details\nline 3: stack trace'
+      );
+    });
+
+    it('handles error without command error section', async () => {
+      const content = [
+        "2024-01-01 12:00:00.123 Error executing process > 'bare'",
+        '',
+        'Caused by:',
+        '  Process terminated',
+        '',
+        'Work dir:',
+        '  /path/to/work/dir'
+      ].join('\n');
+      const logPath = createLogFile(content);
+      const result = await parseNextflowLog(logPath);
+
+      const entry = result.group[0].process[0];
+      expect(entry.status).toBe('error');
+      expect(entry.exitStatus).toBeUndefined();
+      expect(entry.commandError).toBeUndefined();
+      expect(entry.cause).toBe('Process terminated');
+    });
+
+    it('parses multiple error blocks in sequence', async () => {
+      const content = [
+        "2024-01-01 12:00:00.123 Error executing process > 'first'",
+        '',
+        'Command exit status:',
+        '  1',
+        '',
+        'Command error:',
+        '  first failure',
+        '',
+        'Work dir:',
+        '  /path/to/work/dir',
+        '',
+        "2024-01-01 12:00:01.456 Error executing process > 'second'",
+        '',
+        'Command exit status:',
+        '  137',
+        '',
+        'Command error:',
+        '  out of memory',
+        '',
+        'Work dir:',
+        '  /path/to/work/dir2'
+      ].join('\n');
+      const logPath = createLogFile(content);
+      const result = await parseNextflowLog(logPath);
+
+      expect(result.group).toHaveLength(2);
+      expect(result.group[0].name).toBe('first');
+      expect(result.group[0].process[0].exitStatus).toBe('1');
+      expect(result.group[0].process[0].commandError).toBe('first failure');
+      expect(result.group[1].name).toBe('second');
+      expect(result.group[1].process[0].exitStatus).toBe('137');
+      expect(result.group[1].process[0].commandError).toBe('out of memory');
+    });
   });
 
   describe('aborted event', () => {


### PR DESCRIPTION
- Parse multi-line error blocks in nf-parse.ts: capture exitStatus, commandError (stderr), and cause fields from error blocks following Error executing process events
- Display commandError inline on errored tree items in ProgressTracker with collapsible details, OOM chip for exit code 137, and exit status chip for other codes
- Auto-expand tree to show errored processes without manual navigation
- Add translation keys for en and fr locales
- Add tests for multi-line error block parsing and error display

Resolves #119 