### PR TITLE
feat: outdir output isolation + performance fixes

### DIFF
--- a/api-server/index.js
+++ b/api-server/index.js
@@ -152,6 +152,10 @@ app.post('/api/delete-workflow-instance', async (req, res) =>
   post_response(res, call(collection.deleteWorkflowInstance.bind(collection), req.body.instance))
 );
 
+app.post('/api/delete-instance-output', async (req, res) =>
+  post_response(res, call(collection.deleteInstanceOutput.bind(collection), req.body.instance))
+);
+
 app.post('/api/open-results-folder', async (req, res) =>
   post_response(res, call(collection.openResultsFolder.bind(collection), req.body.instance))
 );
@@ -162,6 +166,18 @@ app.post('/api/get-instance-disk-usage', async (req, res) =>
 
 app.post('/api/delete-orphaned-instances', async (req, res) =>
   post_response(res, call(collection.deleteOrphanedInstances.bind(collection)))
+);
+
+app.post('/api/get-instance-reports-list', async (req, res) =>
+  post_response(res, call(collection.getInstanceReportsList.bind(collection), req.body.instance))
+);
+
+app.post('/api/get-path-reports-list', async (req, res) =>
+  post_response(res, call(collection.getPathReportsList.bind(collection), req.body.reportsPath))
+);
+
+app.post('/api/get-output-path-for-instance', async (req, res) =>
+  post_response(res, call(collection.getOutputPathForInstance.bind(collection), req.body.instance))
 );
 
 app.post('/api/hide-workflow-instance', async (req, res) =>
@@ -388,6 +404,22 @@ app.post('/api/get-documents-path', async (req, res) =>
 
 app.post('/api/set-documents-path', async (req, res) =>
   post_response(res, call(collection.setDocumentsPath.bind(collection), req.body.path))
+);
+
+app.post('/api/get-output-path', async (req, res) =>
+  post_response(res, call(collection.getOutputPath.bind(collection)))
+);
+
+app.post('/api/set-output-path', async (req, res) =>
+  post_response(res, call(collection.setOutputPath.bind(collection), req.body.path))
+);
+
+app.post('/api/get-store-dir-path', async (req, res) =>
+  post_response(res, call(collection.getStoreDirPath.bind(collection)))
+);
+
+app.post('/api/set-store-dir-path', async (req, res) =>
+  post_response(res, call(collection.setStoreDirPath.bind(collection), req.body.path))
 );
 
 app.post('/api/get-default-paths', async (req, res) =>

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -154,7 +154,8 @@
     "wipe": "Wipe from disk",
     "wipe_title": "Delete instance from computer",
     "wipe_confirm": "Are you sure you want to permanently delete instance {{name}} from the computer?",
-    "wipe_warning": "Warning: Any output files in the instance folder will also be permanently deleted. This action cannot be undone.",
+    "wipe_warning": "Warning: This action cannot be undone.",
+    "wipe_outputs": "Also delete output files",
     "wipe_success": "Instance {{name}} has been deleted from the computer.",
     "delete_orphaned": "Delete orphaned instances",
     "delete_orphaned_confirm": "Are you sure you want to delete all orphaned (not started) instances?",
@@ -214,8 +215,13 @@
       "open-folder": "Open Folder",
       "open-in-editor": "Open in Editor"
     },
-    "reports": "Reports",
-    "select-report": "Select Report",
+    "reports": {
+      "title": "Reports",
+      "select-report": "Select Report",
+      "instance": "Instance",
+      "output": "Output",
+      "no-reports": "No reports found"
+    },
     "execution": {
       "actions": "Actions",
       "cancel": "Cancel",
@@ -264,6 +270,7 @@
   "settings": {
     "title": "Settings",
     "general": "General",
+    "library": "Library",
     "dark-mode": "Dark Mode",
     "show-log-panel": "Show log panel",
     "collections-path": "Library path",
@@ -280,6 +287,9 @@
     "disable-schema-validation": "Disable strict schema validation",
     "show-hidden-params": "Show hidden parameters",
     "auto-store-dir": "Auto-resolve store_dir parameter",
+    "auto-outdir": "Auto-resolve outdir parameter",
+    "output-folder": "Output folder",
+    "store-dir-folder": "Store dir folder",
     "nextflow-syntax-parser": "Nextflow syntax parser",
     "nextflow-syntax-parser-desc": "Nextflow syntax parser version",
     "project-options": "Projects",

--- a/src/locales/fr/translation.json
+++ b/src/locales/fr/translation.json
@@ -151,7 +151,8 @@
     "wipe": "Effacer du disque",
     "wipe_title": "Supprimer l'instance de l'ordinateur",
     "wipe_confirm": "Êtes-vous sûr de vouloir supprimer définitivement l'instance {{name}} de l'ordinateur ?",
-    "wipe_warning": "Attention : Les fichiers de sortie dans le dossier de l'instance seront également supprimés définitivement. Cette action est irréversible.",
+    "wipe_warning": "Attention : Cette action est irréversible.",
+    "wipe_outputs": "Supprimer également les fichiers de sortie",
     "wipe_success": "L'instance {{name}} a été supprimée de l'ordinateur.",
     "delete_orphaned": "Supprimer les instances orphelines",
     "delete_orphaned_confirm": "Êtes-vous sûr de vouloir supprimer toutes les instances orphelines (non démarrées) ?",
@@ -207,8 +208,13 @@
       "open-folder": "Ouvrir le dossier",
       "open-in-editor": "Ouvrir dans l'éditeur"
     },
-    "reports": "Rapports",
-    "select-report": "Sélectionner le rapport",
+    "reports": {
+      "title": "Rapports",
+      "instance": "Instance",
+      "output": "Sortie",
+      "no-reports": "Aucun rapport trouvé",
+      "select-report": "Sélectionner le rapport"
+    },
     "execution": {
       "actions": "Actions",
       "cancel": "Annuler",
@@ -252,6 +258,7 @@
   "settings": {
     "title": "Paramètres",
     "general": "Général",
+    "library": "Bibliothèque",
     "dark-mode": "Mode sombre",
     "show-log-panel": "Afficher le journal",
     "collections-path": "Chemin de la bibliothèque",
@@ -266,6 +273,9 @@
     "disable-schema-validation": "Désactiver la validation stricte du schéma",
     "show-hidden-params": "Afficher les paramètres cachés",
     "auto-store-dir": "Résolution automatique du paramètre store_dir",
+    "auto-outdir": "Résolution automatique du paramètre outdir",
+    "output-folder": "Dossier de sortie",
+    "store-dir-folder": "Dossier store_dir",
     "nextflow-syntax-parser": "Analyseur syntaxique Nextflow",
     "nextflow-syntax-parser-desc": "Version de l'analyseur syntaxique Nextflow",
     "project-options": "Projets",

--- a/src/main/collection.ts
+++ b/src/main/collection.ts
@@ -27,6 +27,8 @@ import {
 import {
   getConfigPath,
   getDocumentsPath,
+  getOutputPath,
+  getStoreDirPath,
   locateReports,
   getDefaultConfigDir,
   getDefaultDocumentsDir
@@ -335,6 +337,22 @@ function findStoreDirKey(schema: Record<string, any>): string | null {
   for (const defKey of Object.keys(defs)) {
     const defProps = defs[defKey]?.properties ?? {};
     for (const key of storeDirKeys) {
+      if (key in defProps) return key;
+    }
+  }
+  return null;
+}
+
+function findOutdirKey(schema: Record<string, any>): string | null {
+  const outdirKeys = ['outdir', 'outputDir', 'output_dir'];
+  const props = schema?.properties ?? {};
+  for (const key of outdirKeys) {
+    if (key in props) return key;
+  }
+  const defs = schema?.$defs || schema?.definitions || {};
+  for (const defKey of Object.keys(defs)) {
+    const defProps = defs[defKey]?.properties ?? {};
+    for (const key of outdirKeys) {
       if (key in defProps) return key;
     }
   }
@@ -948,6 +966,22 @@ export class Collection {
     await this.parseCollection();
   }
 
+  getOutputPath(): string {
+    return getOutputPath();
+  }
+
+  getStoreDirPath(): string {
+    return getStoreDirPath();
+  }
+
+  async setOutputPath(path: string) {
+    settings.set('outputPath', path);
+  }
+
+  async setStoreDirPath(path: string) {
+    settings.set('storeDirPath', path);
+  }
+
   async createWorkflowInstance(workflow_id: string, version: string): Promise<IWorkflowInstance> {
     const { owner, repo } = parseRepoUrl(workflow_id);
     const workflow = this.workflows.find((wf) => wf.id === `${owner}/${repo}`);
@@ -971,15 +1005,29 @@ export class Collection {
     const instance_path = path.join(this.instances_path, owner, repo_and_version, instance_name);
     this.ensurePathExists(instance_path);
 
-    // Auto-set store_dir if the setting is enabled and the workflow schema has it
-    if (this.settingsGet('autoStoreDir')) {
+    // Auto-set store_dir and outdir if enabled
+    if (this.settingsGet('autoStoreDir') || this.settingsGet('autoOutdir')) {
       const schema = await getWorkflowSchema(workflow_version.path);
-      const storeDirKey = findStoreDirKey(schema);
-      if (storeDirKey) {
-        const storeDirPath = path.join(getDocumentsPath(), 'store_dir');
+      const params: Record<string, string> = {};
+      if (this.settingsGet('autoStoreDir')) {
+        const storeDirKey = findStoreDirKey(schema);
+        if (storeDirKey) {
+          const storeDirPath = getStoreDirPath();
+          params[storeDirKey] = storeDirPath;
+          safeFs.mkdirSync(storeDirPath, { recursive: true });
+        }
+      }
+      if (this.settingsGet('autoOutdir')) {
+        const outdirKey = findOutdirKey(schema);
+        if (outdirKey) {
+          const outputDir = path.join(getOutputPath(), owner, repo_and_version, instance_name);
+          params[outdirKey] = outputDir;
+          safeFs.mkdirSync(outputDir, { recursive: true });
+        }
+      }
+      if (Object.keys(params).length > 0) {
         const paramsFile = path.join(instance_path, 'glacier-params.json');
-        safeFs.writeFileSync(paramsFile, JSON.stringify({ [storeDirKey]: storeDirPath }, null, 2));
-        safeFs.mkdirSync(storeDirPath, { recursive: true });
+        safeFs.writeFileSync(paramsFile, JSON.stringify(params, null, 2));
       }
     }
 
@@ -1302,6 +1350,13 @@ export class Collection {
           console.error(`Failed to update instance database: ${err}`);
         }
       }
+    }
+  }
+
+  async deleteInstanceOutput(instance: IWorkflowInstance): Promise<void> {
+    const outputPath = this.getOutputPathForInstance(instance);
+    if (outputPath && safeFs.existsSync(outputPath)) {
+      safeFs.rmSync(outputPath, { recursive: true, force: true });
     }
   }
 
@@ -1761,6 +1816,23 @@ export class Collection {
 
   getInstanceReportsList(instance: IWorkflowInstance): Record<string, string>[] {
     return locateReports(instance.path);
+  }
+
+  getPathReportsList(reportsPath: string): Record<string, string>[] {
+    return locateReports(reportsPath);
+  }
+
+  getOutputPathForInstance(instance: IWorkflowInstance): string | null {
+    // Look up the workflow to get owner/repo
+    const workflow = this.workflows.find(
+      (w) => w.id === instance.workflow_version.parent_id,
+    );
+    if (!workflow) return null;
+    const version = instance.workflow_version.version || 'latest';
+    const repoAndVersion = `${workflow.repo}@${version}`;
+    const outputDir = path.join(getOutputPath(), workflow.owner, repoAndVersion, instance.name);
+    if (!safeFs.existsSync(outputDir)) return null;
+    return outputDir;
   }
 
   getInstallableReposList(): IRepoVersions[] {

--- a/src/main/ipc-handlers.ts
+++ b/src/main/ipc-handlers.ts
@@ -100,6 +100,10 @@ export function registerIpcHandlers(resourceRoot?: string) {
     return call(collection.deleteWorkflowInstance.bind(collection), instance);
   });
 
+  ipcMain.handle('delete-instance-output', async (event, instance: any) => {
+    return call(collection.deleteInstanceOutput.bind(collection), instance);
+  });
+
   ipcMain.handle('open-results-folder', async (event, instance: any) => {
     return call(collection.openResultsFolder.bind(collection), instance);
   });
@@ -130,6 +134,14 @@ export function registerIpcHandlers(resourceRoot?: string) {
 
   ipcMain.handle('get-instance-reports-list', async (event, instance: any) => {
     return call(collection.getInstanceReportsList.bind(collection), instance);
+  });
+
+  ipcMain.handle('get-path-reports-list', async (event, reportsPath: string) => {
+    return call(collection.getPathReportsList.bind(collection), reportsPath);
+  });
+
+  ipcMain.handle('get-output-path-for-instance', async (event, instance: any) => {
+    return call(collection.getOutputPathForInstance.bind(collection), instance);
   });
 
   ipcMain.handle('open-work-folder', async (event, instance: any, work_id: string) => {
@@ -177,6 +189,22 @@ export function registerIpcHandlers(resourceRoot?: string) {
 
   ipcMain.handle('set-documents-path', (event, path) => {
     return call(collection.setDocumentsPath.bind(collection), path);
+  });
+
+  ipcMain.handle('get-output-path', () => {
+    return call(collection.getOutputPath.bind(collection));
+  });
+
+  ipcMain.handle('set-output-path', (event, path) => {
+    return call(collection.setOutputPath.bind(collection), path);
+  });
+
+  ipcMain.handle('get-store-dir-path', () => {
+    return call(collection.getStoreDirPath.bind(collection));
+  });
+
+  ipcMain.handle('set-store-dir-path', (event, path) => {
+    return call(collection.setStoreDirPath.bind(collection), path);
   });
 
   ipcMain.handle('get-default-paths', () => {

--- a/src/main/paths.ts
+++ b/src/main/paths.ts
@@ -54,6 +54,22 @@ export function getDocumentsPath(): string {
   return store.get('documentsPath') || getDefaultDocumentsDir();
 }
 
+export function getDefaultOutputDir(): string {
+  return path.join(getDocumentsPath(), 'output');
+}
+
+export function getDefaultStoreDir(): string {
+  return path.join(getDocumentsPath(), 'store_dir');
+}
+
+export function getStoreDirPath(): string {
+  return store.get('storeDirPath') || getDefaultStoreDir();
+}
+
+export function getOutputPath(): string {
+  return store.get('outputPath') || getDefaultOutputDir();
+}
+
 // Backward-compat aliases
 export function getCollectionsPath(): string {
   return getConfigPath();

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -19,11 +19,17 @@ contextBridge.exposeInMainWorld('electronAPI', {
   killWorkflowInstance: (instance: any) => ipcRenderer.invoke('kill-workflow-instance', instance),
   deleteWorkflowInstance: (instance: any) =>
     ipcRenderer.invoke('delete-workflow-instance', instance),
+  deleteInstanceOutput: (instance: any) =>
+    ipcRenderer.invoke('delete-instance-output', instance),
   openResultsFolder: (instance: any) => ipcRenderer.invoke('open-results-folder', instance),
   updateWorkflowInstanceStatus: (instance: any) =>
     ipcRenderer.invoke('update-workflow-instance-status', instance),
   getInstanceReportsList: (instance: any) =>
     ipcRenderer.invoke('get-instance-reports-list', instance),
+  getPathReportsList: (reportsPath: string) =>
+    ipcRenderer.invoke('get-path-reports-list', reportsPath),
+  getOutputPathForInstance: (instance: any) =>
+    ipcRenderer.invoke('get-output-path-for-instance', instance),
   openWorkFolder: (instance: any, work_id: string) =>
     ipcRenderer.invoke('open-work-folder', instance, work_id),
   openLogFile: (instance: any, log_type: string) =>
@@ -49,6 +55,10 @@ contextBridge.exposeInMainWorld('electronAPI', {
   setConfigPath: (path: string) => ipcRenderer.invoke('set-config-path', path),
   getDocumentsPath: () => ipcRenderer.invoke('get-documents-path'),
   setDocumentsPath: (path: string) => ipcRenderer.invoke('set-documents-path', path),
+  getOutputPath: () => ipcRenderer.invoke('get-output-path'),
+  setOutputPath: (path: string) => ipcRenderer.invoke('set-output-path', path),
+  getStoreDirPath: () => ipcRenderer.invoke('get-store-dir-path'),
+  setStoreDirPath: (path: string) => ipcRenderer.invoke('set-store-dir-path', path),
   getDefaultPaths: () => ipcRenderer.invoke('get-default-paths'),
   getMissingPaths: () => ipcRenderer.invoke('get-missing-paths'),
   getCollectionRepos: () => ipcRenderer.invoke('get-collection-repos'),

--- a/src/main/store.ts
+++ b/src/main/store.ts
@@ -18,6 +18,9 @@ export interface StoreSchema {
   showLogPanel: boolean;
   autoStoreDir: boolean;
   nextflowSyntaxParser: string;
+  autoOutdir: boolean;
+  outputPath: string;
+  storeDirPath: string;
 }
 
 let _instance: any = null;
@@ -41,7 +44,10 @@ function getInstance() {
           instanceSortDir: { type: 'string', default: 'asc' },
           showLogPanel: { type: 'boolean', default: false },
           autoStoreDir: { type: 'boolean', default: true },
-          nextflowSyntaxParser: { type: 'string', default: '1' }
+          nextflowSyntaxParser: { type: 'string', default: '1' },
+          autoOutdir: { type: 'boolean', default: true },
+          outputPath: { type: 'string', default: '' },
+          storeDirPath: { type: 'string', default: '' }
         },
         name: 'config',
         projectName: 'GLACIER',

--- a/src/renderer/pages/Instances.tsx
+++ b/src/renderer/pages/Instances.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useMemo } from 'react';
+import React, { useState, useEffect, useMemo, useCallback } from 'react';
 import {
   Box,
   Container,
@@ -21,7 +21,9 @@ import {
   InputAdornment,
   Select,
   FormControl,
-  InputLabel
+  InputLabel,
+  FormControlLabel,
+  Checkbox
 } from '@mui/material';
 import Accordion from '@mui/material/Accordion';
 import AccordionSummary from '@mui/material/AccordionSummary';
@@ -97,7 +99,7 @@ const statusColor = (status: string | undefined) => {
   }
 };
 
-const InstanceAccordion = ({
+const InstanceAccordion = React.memo(function InstanceAccordion({
   instance,
   instanceName,
   workflowName,
@@ -107,7 +109,7 @@ const InstanceAccordion = ({
   handleWipeInstance,
   expanded,
   onToggle
-}) => {
+}) {
   const { t } = useTranslation();
   const [diskUsage, setDiskUsage] = useState<number | null>(null);
   const [diskLoading, setDiskLoading] = useState(false);
@@ -329,9 +331,10 @@ const InstanceAccordion = ({
       </Dialog>
     </>
   );
-};
+});
 
 export default function InstancesPage({
+
   instancesList,
   refreshInstancesList,
   logMessage,
@@ -341,12 +344,13 @@ export default function InstancesPage({
 }) {
   const { t } = useTranslation();
 
-  const [rows, setRows] = useState([]);
   const [editingInstance, setEditingInstance] = useState<string | null>(null);
   const [justLaunchedId, setJustLaunchedId] = useState<string | null>(null);
   const [initialMonitorTab, setInitialMonitorTab] = useState(0);
   const [wipeDialogOpen, setWipeDialogOpen] = useState(false);
   const [wipeTarget, setWipeTarget] = useState<{ instance: any; name: string } | null>(null);
+  const [wipeOutputs, setWipeOutputs] = useState(false);
+  const [wipeOutputAvailable, setWipeOutputAvailable] = useState(false);
   const [expandedAccordion, setExpandedAccordion] = useState<string | null>(null);
   const [menuAnchorEl, setMenuAnchorEl] = useState<null | HTMLElement>(null);
   const [hiddenDialogOpen, setHiddenDialogOpen] = useState(false);
@@ -396,19 +400,6 @@ export default function InstancesPage({
     if (item === '') setJustLaunchedId(null);
   }, [item]);
 
-  useEffect(() => {
-    setRows(
-      instancesList.map((item) =>
-        createData(
-          item.instance.status,
-          item.instance.id,
-          item.name,
-          item.instance.workflow_version.name
-        )
-      )
-    );
-  }, [instancesList]);
-
   // Poll instances list every 5 seconds when in list view
   useEffect(() => {
     if (item !== '') return;
@@ -429,24 +420,29 @@ export default function InstancesPage({
     refreshInstancesList();
   };
 
-  const createData = (status: string, id: string, name: string, workflow: string) => {
-    return { status, id, name, workflow };
-  };
-
-  const handleWipeInstance = (instance, name) => {
+  const handleWipeInstance = useCallback((instance, name) => {
     setWipeTarget({ instance, name });
+    setWipeOutputs(false);
+    API.getOutputPathForInstance(instance).then((result) => {
+      setWipeOutputAvailable(result.ok && !!result.data);
+    });
     setWipeDialogOpen(true);
-  };
+  }, []);
 
   const confirmWipe = async () => {
     if (!wipeTarget) return;
     const result = await API.deleteWorkflowInstance(wipeTarget.instance);
     if (result.ok) {
+      if (wipeOutputs) {
+        await API.deleteInstanceOutput(wipeTarget.instance);
+      }
       logMessage(t('instances.wipe_success', { name: wipeTarget.name }), 'info');
       refreshInstancesList();
     }
     setWipeDialogOpen(false);
     setWipeTarget(null);
+    setWipeOutputs(false);
+    setWipeOutputAvailable(false);
   };
 
   const handleDeleteOrphaned = async () => {
@@ -624,6 +620,17 @@ export default function InstancesPage({
               <Typography>
                 {t('instances.wipe_confirm', { name: wipeTarget?.name || '' })}
               </Typography>
+              <FormControlLabel
+                control={
+                  <Checkbox
+                    checked={wipeOutputs}
+                    disabled={!wipeOutputAvailable}
+                    onChange={(e) => setWipeOutputs(e.target.checked)}
+                  />
+                }
+                label={t('instances.wipe_outputs')}
+                sx={{ mt: 2 }}
+              />
               <Typography variant="body2" color="error" sx={{ mt: 1 }}>
                 {t('instances.wipe_warning')}
               </Typography>
@@ -679,7 +686,7 @@ export default function InstancesPage({
         instancesList
           .filter(({ name }) => name === item)
           .map(({ name, instance }) => {
-            const status = rows.find((r) => r.name === name)?.status;
+            const status = instancesList.find((r) => r.name === name)?.instance?.status;
             return status == WorkflowStatus.Created || editingInstance === name ? (
               <ParametersPage
                 key={instance.id}

--- a/src/renderer/pages/Main.tsx
+++ b/src/renderer/pages/Main.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useCallback } from 'react';
 import {
   Box,
   Drawer,
@@ -57,13 +57,16 @@ export default function MainPage({ darkMode, setDarkMode }) {
   const [showLogPanel, setShowLogPanel] = useState(false);
   const [autoStoreDir, setAutoStoreDir] = useState(false);
   const [nextflowSyntaxParser, setNextflowSyntaxParser] = useState('1');
+  const [autoOutdir, setAutoOutdir] = useState(true);
+  const [outputPath, setOutputPath] = useState('');
+  const [storeDirPath, setStoreDirPath] = useState('');
   const [open, setOpen] = useState(false);
   const [item, setItem] = useState('');
   const [navigateToSettingsPage, setNavigateToSettingsPage] = useState('');
   const [catalogueParseResults, setCatalogueParseResults] = useState([]);
   const [showCatalogueParseErrors, setShowCatalogueParseErrors] = useState(false);
 
-  const refreshInstancesList = async () => {
+  const refreshInstancesList = useCallback(async () => {
     API.listWorkflowInstances().then((result) => {
       if (!result.ok) return;
       setInstancesList(
@@ -73,7 +76,7 @@ export default function MainPage({ darkMode, setDarkMode }) {
         }))
       );
     });
-  };
+  }, []);
 
   useEffect(() => {
     (async () => {
@@ -100,6 +103,15 @@ export default function MainPage({ darkMode, setDarkMode }) {
       });
       API.settingsGet(SettingsKey.NextflowSyntaxParser).then((result) => {
         if (result.ok) setNextflowSyntaxParser(result.data);
+      });
+      API.settingsGet(SettingsKey.AutoOutdir).then((result) => {
+        if (result.ok) setAutoOutdir(result.data);
+      });
+      API.getOutputPath().then((result) => {
+        if (result.ok) setOutputPath(result.data);
+      });
+      API.getStoreDirPath().then((result) => {
+        if (result.ok) setStoreDirPath(result.data);
       });
       const r = await API.init();
       if (!r.ok) {
@@ -339,6 +351,12 @@ export default function MainPage({ darkMode, setDarkMode }) {
                 setAutoStoreDir={setAutoStoreDir}
                 nextflowSyntaxParser={nextflowSyntaxParser}
                 setNextflowSyntaxParser={setNextflowSyntaxParser}
+                autoOutdir={autoOutdir}
+                setAutoOutdir={setAutoOutdir}
+                outputPath={outputPath}
+                setOutputPath={setOutputPath}
+                storeDirPath={storeDirPath}
+                setStoreDirPath={setStoreDirPath}
                 navigateToPage={navigateToSettingsPage}
                 setNavigateToPage={setNavigateToSettingsPage}
                 onReopenSetup={() => {

--- a/src/renderer/pages/Monitor/HtmlReports.tsx
+++ b/src/renderer/pages/Monitor/HtmlReports.tsx
@@ -1,25 +1,53 @@
 import React, { useEffect } from 'react';
-import { Box, CircularProgress } from '@mui/material';
+import { Box, CircularProgress, Select, MenuItem, Typography } from '@mui/material';
 import List from '@mui/material/List';
 import ListItemText from '@mui/material/ListItemText';
 import ListItemButton from '@mui/material/ListItemButton';
 import Tooltip from '@mui/material/Tooltip';
 import { API } from '../../services/api.js';
+import { useTranslation } from 'react-i18next';
 
 export default function HtmlReports({ instance }) {
+  const { t } = useTranslation();
   const [loading, setLoading] = React.useState(false);
   const [selected, setSelected] = React.useState(null);
   const [reportsList, setReportsList] = React.useState<Record<string, string>[]>([]);
+  const [source, setSource] = React.useState<'instance' | 'output'>('instance');
+  const [outputPathAvailable, setOutputPathAvailable] = React.useState(false);
 
   useEffect(() => {
-    API.getInstanceReportsList(instance).then((result) => {
-      if (result.ok) {
-        const list = result.data || [];
-        setReportsList(list);
-        if (list.length > 0) setSelected(list[0]);
-      }
+    API.getOutputPathForInstance(instance).then((result) => {
+      const available = result.ok && !!result.data;
+      setOutputPathAvailable(available);
+      if (available) setSource('output');
     });
   }, [instance]);
+
+  useEffect(() => {
+    setSelected(null);
+    setReportsList([]);
+    if (source === 'instance') {
+      API.getInstanceReportsList(instance).then((result) => {
+        if (result.ok) {
+          const list = result.data || [];
+          setReportsList(list);
+          if (list.length > 0) setSelected(list[0]);
+        }
+      });
+    } else {
+      API.getOutputPathForInstance(instance).then((pathResult) => {
+        if (pathResult.ok && pathResult.data) {
+          API.getPathReportsList(pathResult.data).then((result) => {
+            if (result.ok) {
+              const list = result.data || [];
+              setReportsList(list);
+              if (list.length > 0) setSelected(list[0]);
+            }
+          });
+        }
+      });
+    }
+  }, [instance, source]);
 
   useEffect(() => {
     if (selected?.path) setLoading(true);
@@ -37,31 +65,50 @@ export default function HtmlReports({ instance }) {
     >
       {/* Report list */}
       <Box sx={{ overflow: 'auto', borderRight: selected ? '1px solid' : 'none' }}>
-        <List dense disablePadding>
-          {reportsList.map((report) => (
-            <ListItemButton
-              key={report.id}
-              selected={selected?.id === report.id}
-              onClick={() => setSelected(report)}
-              sx={{ py: 0.5, minWidth: 0 }}
+        {outputPathAvailable && (
+          <Box sx={{ p: 1 }}>
+            <Select
+              size="small"
+              value={source}
+              onChange={(e) => setSource(e.target.value as 'instance' | 'output')}
+              sx={{ width: '100%' }}
             >
-              <Tooltip title={report.name} placement="right">
-                <ListItemText
-                  primary={report.name}
-                  secondary={
-                    report.shortPath ? report.shortPath.split('/').slice(0, -1).join('/') : ''
-                  }
-                  primaryTypographyProps={{ noWrap: true }}
-                  secondaryTypographyProps={{
-                    variant: 'caption',
-                    color: 'text.secondary',
-                    noWrap: true
-                  }}
-                />
-              </Tooltip>
-            </ListItemButton>
-          ))}
-        </List>
+              <MenuItem value="instance">{t('monitor.reports.instance')}</MenuItem>
+              <MenuItem value="output">{t('monitor.reports.output')}</MenuItem>
+            </Select>
+          </Box>
+        )}
+        {reportsList.length > 0 ? (
+          <List dense disablePadding>
+            {reportsList.map((report) => (
+              <ListItemButton
+                key={report.id}
+                selected={selected?.id === report.id}
+                onClick={() => setSelected(report)}
+                sx={{ py: 0.5, minWidth: 0 }}
+              >
+                <Tooltip title={report.name} placement="right">
+                  <ListItemText
+                    primary={report.name}
+                    secondary={
+                      report.shortPath ? report.shortPath.split('/').slice(0, -1).join('/') : ''
+                    }
+                    primaryTypographyProps={{ noWrap: true }}
+                    secondaryTypographyProps={{
+                      variant: 'caption',
+                      color: 'text.secondary',
+                      noWrap: true
+                    }}
+                  />
+                </Tooltip>
+              </ListItemButton>
+            ))}
+          </List>
+        ) : (
+          <Typography variant="body2" sx={{ p: 2, color: 'text.secondary' }}>
+            {t('monitor.reports.no-reports')}
+          </Typography>
+        )}
       </Box>
 
       {/* Report viewer */}

--- a/src/renderer/pages/Monitor/Monitor.tsx
+++ b/src/renderer/pages/Monitor/Monitor.tsx
@@ -81,7 +81,7 @@ export default function MonitorPage({
       )}
       <Tabs value={tabSelected} onChange={handleTabChange}>
         <Tab label={t('monitor.progress.title')} />
-        <Tab label={t('monitor.reports')} />
+        <Tab label={t('monitor.reports.title')} />
         <Tab label={t('monitor.logs.title')} />
       </Tabs>
       <TabPanel value={tabSelected} index={0}>

--- a/src/renderer/pages/Settings/Settings.tsx
+++ b/src/renderer/pages/Settings/Settings.tsx
@@ -4,6 +4,7 @@ import {
   Typography,
   TextField,
   Switch,
+  Checkbox,
   FormControlLabel,
   Select,
   Stack,
@@ -40,6 +41,12 @@ export default function SettingsPage({
   setAutoStoreDir,
   nextflowSyntaxParser,
   setNextflowSyntaxParser,
+  autoOutdir,
+  setAutoOutdir,
+  outputPath,
+  setOutputPath,
+  storeDirPath,
+  setStoreDirPath,
   navigateToPage,
   setNavigateToPage,
   onReopenSetup
@@ -105,6 +112,29 @@ export default function SettingsPage({
     });
   };
 
+  const handleAutoOutdir = (value) => {
+    setAutoOutdir(value);
+    API.settingsSet(SettingsKey.AutoOutdir, value).then((result) => {
+      if (!result.ok) console.error(result.error.message);
+    });
+  };
+
+  const handlePickOutputPath = async () => {
+    const result = await API.pickDirectory();
+    if (result.ok && result.data) {
+      setOutputPath(result.data);
+      API.setOutputPath(result.data);
+    }
+  };
+
+  const handlePickStoreDirPath = async () => {
+    const result = await API.pickDirectory();
+    if (result.ok && result.data) {
+      setStoreDirPath(result.data);
+      API.setStoreDirPath(result.data);
+    }
+  };
+
   const handleNextflowSyntaxParser = (value) => {
     setNextflowSyntaxParser(value);
     API.settingsSet(SettingsKey.NextflowSyntaxParser, value).then((result) => {
@@ -132,7 +162,7 @@ export default function SettingsPage({
 
   useEffect(() => {
     if (navigateToPage === 'environment') {
-      setTabValue(3);
+      setTabValue(4);
       setNavigateToPage('');
     }
   }, [navigateToPage]);
@@ -173,6 +203,7 @@ export default function SettingsPage({
         sx={{ borderRight: 1, borderColor: 'divider' }}
       >
         <Tab id="settings-general-panel" label={t('settings.general')} />
+        <Tab id="settings-library-panel" label={t('settings.library')} />
         <Tab id="settings-visual-panel" label={t('settings.visual-options')} />
         <Tab id="settings-language-panel" label={t('settings.language-select')} />
         <Tab id="settings-environment-panel" label={t('settings.environment-options')} />
@@ -204,47 +235,100 @@ export default function SettingsPage({
         </Box>
         <FormControlLabel
           control={
-            <Switch
-              id="settings-permit-add-catalogues"
-              checked={permitAddCatalogues}
-              onChange={(_, checked) => handlePermitAddCatalogues(checked)}
+            <Checkbox
+              checked={autoOutdir}
+              onChange={(e) => handleAutoOutdir(e.target.checked)}
             />
           }
-          label={t('settings.permit-add-catalogues')}
+          label={t('settings.auto-outdir', 'Auto-resolve outdir parameter')}
         />
+        <Box sx={{ pl: 4, mb: 2, opacity: autoOutdir ? 1 : 0.5 }}>
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+            <TextField
+              label={t('settings.output-folder', 'Output folder')}
+              value={outputPath || ''}
+              fullWidth
+              size="small"
+              disabled={!autoOutdir}
+              slotProps={{ input: { readOnly: true } }}
+            />
+            <Button variant="outlined" onClick={handlePickOutputPath} disabled={!autoOutdir}>
+              {t('setup.browse', 'Browse')}
+            </Button>
+          </Box>
+        </Box>
         <FormControlLabel
           control={
-            <Switch
-              id="settings-permit-catalogue-modifications"
-              checked={permitCatalogueModifications}
-              onChange={(_, checked) => handlePermitCatalogueModifications(checked)}
+            <Checkbox
+              checked={autoStoreDir}
+              onChange={(e) => handleAutoStoreDir(e.target.checked)}
             />
           }
-          label={t('settings.permit-catalogue-modifications')}
+          label={t('settings.auto-store-dir')}
         />
-        <FormControlLabel
-          control={
-            <Switch
-              id="settings-permit-import-shards"
-              checked={permitImportShards}
-              onChange={(_, checked) => handlePermitImportShards(checked)}
+        <Box sx={{ pl: 4, mb: 2, opacity: autoStoreDir ? 1 : 0.5 }}>
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+            <TextField
+              label={t('settings.store-dir-folder', 'Store dir folder')}
+              value={storeDirPath || ''}
+              fullWidth
+              size="small"
+              disabled={!autoStoreDir}
+              slotProps={{ input: { readOnly: true } }}
             />
-          }
-          label={t('settings.permit-import-shards')}
-        />
-        <FormControlLabel
-          control={
-            <Switch
-              id="settings-permit-add-repos"
-              checked={permitAddRepos}
-              onChange={(_, checked) => handlePermitAddRepos(checked)}
-            />
-          }
-          label={t('settings.permit-add-repos')}
-        />
+            <Button variant="outlined" onClick={handlePickStoreDirPath} disabled={!autoStoreDir}>
+              {t('setup.browse', 'Browse')}
+            </Button>
+          </Box>
+        </Box>
       </TabPanel>
 
       <TabPanel value={tabValue} index={1}>
+        <Stack spacing={2} sx={{ mt: 2 }}>
+          <FormControlLabel
+            control={
+              <Switch
+                id="settings-permit-add-catalogues"
+                checked={permitAddCatalogues}
+                onChange={(_, checked) => handlePermitAddCatalogues(checked)}
+              />
+            }
+            label={t('settings.permit-add-catalogues')}
+          />
+          <FormControlLabel
+            control={
+              <Switch
+                id="settings-permit-catalogue-modifications"
+                checked={permitCatalogueModifications}
+                onChange={(_, checked) => handlePermitCatalogueModifications(checked)}
+              />
+            }
+            label={t('settings.permit-catalogue-modifications')}
+          />
+          <FormControlLabel
+            control={
+              <Switch
+                id="settings-permit-import-shards"
+                checked={permitImportShards}
+                onChange={(_, checked) => handlePermitImportShards(checked)}
+              />
+            }
+            label={t('settings.permit-import-shards')}
+          />
+          <FormControlLabel
+            control={
+              <Switch
+                id="settings-permit-add-repos"
+                checked={permitAddRepos}
+                onChange={(_, checked) => handlePermitAddRepos(checked)}
+              />
+            }
+            label={t('settings.permit-add-repos')}
+          />
+        </Stack>
+      </TabPanel>
+
+      <TabPanel value={tabValue} index={2}>
         <Stack spacing={2}>
           <FormControlLabel
             control={
@@ -261,7 +345,7 @@ export default function SettingsPage({
         </Stack>
       </TabPanel>
 
-      <TabPanel value={tabValue} index={2}>
+      <TabPanel value={tabValue} index={3}>
         <Select
           labelId="settings-language-select-label"
           id="settings-language-select"
@@ -275,11 +359,11 @@ export default function SettingsPage({
       </TabPanel>
 
       {/* Update useEffect if environment tab index changes */}
-      <TabPanel value={tabValue} index={3}>
+      <TabPanel value={tabValue} index={4}>
         <EnvironmentPage />
       </TabPanel>
 
-      <TabPanel value={tabValue} index={4}>
+      <TabPanel value={tabValue} index={5}>
         <Stack spacing={2}>
           <Box>
             <Typography variant="body2" sx={{ mb: 1, color: 'text.secondary' }}>
@@ -314,19 +398,10 @@ export default function SettingsPage({
             }
             label={t('settings.show-hidden-params')}
           />
-          <FormControlLabel
-            control={
-              <Switch
-                checked={autoStoreDir}
-                onChange={(_, checked) => handleAutoStoreDir(checked)}
-              />
-            }
-            label={t('settings.auto-store-dir')}
-          />
         </Stack>
       </TabPanel>
 
-      <TabPanel value={tabValue} index={5}>
+      <TabPanel value={tabValue} index={6}>
         <LicensesPage />
       </TabPanel>
     </Paper>

--- a/src/renderer/services/api.ts
+++ b/src/renderer/services/api.ts
@@ -18,6 +18,7 @@ const electronAPI = isElectron
         window.electronAPI.resetWorkflowInstanceStatus(instance),
       killWorkflowInstance: (instance) => window.electronAPI.killWorkflowInstance(instance),
       deleteWorkflowInstance: (instance) => window.electronAPI.deleteWorkflowInstance(instance),
+      deleteInstanceOutput: (instance) => window.electronAPI.deleteInstanceOutput(instance),
       openResultsFolder: (instance) => window.electronAPI.openResultsFolder(instance),
       openLogFile: (instance, logType) => window.electronAPI.openLogFile(instance, logType),
       openWorkLogFile: (instance, workID, logType) =>
@@ -25,6 +26,8 @@ const electronAPI = isElectron
       updateWorkflowInstanceStatus: (instance) =>
         window.electronAPI.updateWorkflowInstanceStatus(instance),
       getInstanceReportsList: (instance) => window.electronAPI.getInstanceReportsList(instance),
+      getPathReportsList: (reportsPath) => window.electronAPI.getPathReportsList(reportsPath),
+      getOutputPathForInstance: (instance) => window.electronAPI.getOutputPathForInstance(instance),
       getInstanceReport: (instance, reportFile) =>
         window.electronAPI.getInstanceReport(instance, reportFile),
       openWorkFolder: (instance, workID) => window.electronAPI.openWorkFolder(instance, workID),
@@ -79,6 +82,10 @@ const electronAPI = isElectron
       setConfigPath: (path) => window.electronAPI.setConfigPath(path),
       getDocumentsPath: () => window.electronAPI.getDocumentsPath(),
       setDocumentsPath: (path) => window.electronAPI.setDocumentsPath(path),
+      getOutputPath: () => window.electronAPI.getOutputPath(),
+      setOutputPath: (path) => window.electronAPI.setOutputPath(path),
+      getStoreDirPath: () => window.electronAPI.getStoreDirPath(),
+      setStoreDirPath: (path) => window.electronAPI.setStoreDirPath(path),
       getDefaultPaths: () => window.electronAPI.getDefaultPaths(),
       getMissingPaths: () => window.electronAPI.getMissingPaths(),
       getContainerLogs: (containerId) => window.electronAPI.getContainerLogs(containerId),
@@ -149,6 +156,8 @@ const httpAPI = {
     httpDispatch('/api/kill-workflow-instance', 'POST', { instance }),
   deleteWorkflowInstance: async (instance) =>
     httpDispatch('/api/delete-workflow-instance', 'POST', { instance }),
+  deleteInstanceOutput: async (instance) =>
+    httpDispatch('/api/delete-instance-output', 'POST', { instance }),
   openResultsFolder: async (instance) =>
     httpDispatch('/api/open-results-folder', 'POST', { instance }),
   openLogFile: async (instance, logType) =>
@@ -159,6 +168,10 @@ const httpAPI = {
     httpDispatch('/api/update-workflow-instance-status', 'POST', { instance }),
   getInstanceReportsList: async (instance) =>
     httpDispatch('/api/get-instance-reports-list', 'POST', { instance }),
+  getPathReportsList: async (reportsPath) =>
+    httpDispatch('/api/get-path-reports-list', 'POST', { reportsPath }),
+  getOutputPathForInstance: async (instance) =>
+    httpDispatch('/api/get-output-path-for-instance', 'POST', { instance }),
   getInstanceReport: async (instance, reportFile) =>
     httpDispatch('/api/get-instance-report', 'POST', { instance, reportFile }),
   openWorkFolder: async (instance, workID) =>
@@ -237,6 +250,10 @@ const httpAPI = {
   setConfigPath: async (path) => httpDispatch('/api/set-config-path', 'POST', { path }),
   getDocumentsPath: async () => httpDispatch('/api/get-documents-path', 'POST', {}),
   setDocumentsPath: async (path) => httpDispatch('/api/set-documents-path', 'POST', { path }),
+  getOutputPath: async () => httpDispatch('/api/get-output-path', 'POST', {}),
+  setOutputPath: async (path) => httpDispatch('/api/set-output-path', 'POST', { path }),
+  getStoreDirPath: async () => httpDispatch('/api/get-store-dir-path', 'POST', {}),
+  setStoreDirPath: async (path) => httpDispatch('/api/set-store-dir-path', 'POST', { path }),
   getDefaultPaths: async () => httpDispatch('/api/get-default-paths', 'POST', {}),
   getMissingPaths: async () => httpDispatch('/api/get-missing-paths', 'POST', {}),
   getContainerLogs: async (containerId) =>

--- a/src/types/settings.ts
+++ b/src/types/settings.ts
@@ -12,7 +12,10 @@ export const SettingsKey = {
   InstanceSortDir: 'instanceSortDir',
   ShowLogPanel: 'showLogPanel',
   AutoStoreDir: 'autoStoreDir',
-  NextflowSyntaxParser: 'nextflowSyntaxParser'
+  NextflowSyntaxParser: 'nextflowSyntaxParser',
+  AutoOutdir: 'autoOutdir',
+  OutputPath: 'outputPath',
+  StoreDirPath: 'storeDirPath'
 } as const;
 
 export type SettingsKey = (typeof SettingsKey)[keyof typeof SettingsKey];

--- a/tests/e2e/ui.spec.ts
+++ b/tests/e2e/ui.spec.ts
@@ -51,6 +51,9 @@ test('clone a repository', async ({ page }) => {
   await page.fill('#setup-documents-folder', `${docs_path}`);
   await page.click('#setup-continue-button');
 
+  // Navigate to Library tab (permissions switches were moved here)
+  await page.click('#settings-library-panel');
+
   // Ensure repositories and catalogues can be modified in settings
   await page.check('#settings-permit-add-catalogues');
   await page.check('#settings-permit-catalogue-modifications');
@@ -145,4 +148,87 @@ test('launch local workflow', async ({ page }) => {
   await expect(page.getByText('Completed')).toBeVisible({
     timeout: TIMEOUT_30s
   });
+});
+
+async function runOutdirWorkflow(
+  page: Page,
+  docsPath: string,
+  autoOutdirOn: boolean,
+): Promise<string> {
+  // Set autoOutdir to desired state
+  await page.click('#sidebar-settings-button');
+  await page.click('#settings-general-panel');
+  const checkbox = page.getByLabel('Auto-resolve outdir parameter');
+  if (autoOutdirOn) {
+    await checkbox.check();
+  } else {
+    await checkbox.uncheck();
+  }
+
+  // Navigate to Library and select outdir workflow
+  await page.click('#sidebar-library-button');
+  await page.click('#card-outdir');
+
+  // Extract instance name from Parameters page header: "[<name>] <workflow name>"
+  const headerText = await page.locator('h6').filter({ hasText: /\[/ }).first().textContent();
+  const instanceName = headerText?.match(/\[(.+?)\]/)?.[1];
+  if (!instanceName) throw new Error('Could not extract instance name from header');
+
+  // Launch workflow
+  await page.getByRole('button', { name: 'Launch Workflow' }).click();
+
+  // Wait for completion
+  await expect(page.getByText('Completed')).toBeVisible({ timeout: TIMEOUT_60s });
+
+  return instanceName;
+}
+
+test('outdir workflow — autoOutdir OFF', async ({ page }) => {
+  const local_collections_path = path.resolve(path.join(__dirname, '..', 'test-data'));
+  const docs_path = path.resolve(path.join(os.tmpdir(), 'GLACIER-docs-' + Date.now().toString()));
+  fs.mkdirSync(docs_path, { recursive: true });
+
+  // Setup paths
+  await page.click('#sidebar-settings-button');
+  await page.click('#settings-general-panel');
+  await page.click('#settings-reopen-setup');
+  await page.fill('#setup-config-folder', `${local_collections_path}`);
+  await page.fill('#setup-documents-folder', `${docs_path}`);
+  await page.click('#setup-continue-button');
+
+  const instanceName = await runOutdirWorkflow(page, docs_path, false);
+
+  // With autoOutdir OFF, outdir defaults to ./results inside the instance path
+  const instancePath = path.join(docs_path, 'instances', 'glacier', 'outdir@main', instanceName);
+  expect(fs.existsSync(path.join(instancePath, 'results', 'output.txt'))).toBe(true);
+  expect(fs.existsSync(path.join(instancePath, 'results', 'report.html'))).toBe(true);
+
+  // Output directory should not contain these files
+  const outputPath = path.join(docs_path, 'output', 'glacier', 'outdir@main', instanceName);
+  expect(fs.existsSync(path.join(outputPath, 'output.txt'))).toBe(false);
+});
+
+test('outdir workflow — autoOutdir ON', async ({ page }) => {
+  const local_collections_path = path.resolve(path.join(__dirname, '..', 'test-data'));
+  const docs_path = path.resolve(path.join(os.tmpdir(), 'GLACIER-docs-' + Date.now().toString()));
+  fs.mkdirSync(docs_path, { recursive: true });
+
+  // Setup paths
+  await page.click('#sidebar-settings-button');
+  await page.click('#settings-general-panel');
+  await page.click('#settings-reopen-setup');
+  await page.fill('#setup-config-folder', `${local_collections_path}`);
+  await page.fill('#setup-documents-folder', `${docs_path}`);
+  await page.click('#setup-continue-button');
+
+  const instanceName = await runOutdirWorkflow(page, docs_path, true);
+
+  // With autoOutdir ON, files should be in the output directory
+  const outputPath = path.join(docs_path, 'output', 'glacier', 'outdir@main', instanceName);
+  expect(fs.existsSync(path.join(outputPath, 'output.txt'))).toBe(true);
+  expect(fs.existsSync(path.join(outputPath, 'report.html'))).toBe(true);
+
+  // Instance path should not have a results folder (files went to outdir instead)
+  const instancePath = path.join(docs_path, 'instances', 'glacier', 'outdir@main', instanceName);
+  expect(fs.existsSync(path.join(instancePath, 'results'))).toBe(false);
 });

--- a/tests/test-data/catalogues/user_collection/store/catalogue.json
+++ b/tests/test-data/catalogues/user_collection/store/catalogue.json
@@ -6,11 +6,6 @@
       "name": "My Workflows",
       "workflows": [
         {
-          "name": "sleep",
-          "repo": "glacier/sleep",
-          "version": "main"
-        },
-        {
           "name": "exit1",
           "repo": "glacier/exit1",
           "version": "main"
@@ -21,8 +16,18 @@
           "version": "main"
         },
         {
+          "name": "sleep",
+          "repo": "glacier/sleep",
+          "version": "main"
+        },
+        {
           "name": "timeout",
           "repo": "glacier/timeout",
+          "version": "main"
+        },
+        {
+          "name": "outdir",
+          "repo": "glacier/outdir",
           "version": "main"
         }
       ]

--- a/tests/test-data/workflows/glacier/outdir@main/main.nf
+++ b/tests/test-data/workflows/glacier/outdir@main/main.nf
@@ -1,0 +1,40 @@
+#!/usr/bin/env nextflow
+nextflow.enable.dsl=2
+
+params.outdir = "./results"
+
+process WRITE_OUTPUT {
+    publishDir "${params.outdir}", mode: 'copy'
+
+    output:
+    path "output.txt"
+
+    script:
+    """
+    echo "output from ${params.message}" > output.txt
+    """
+}
+
+process WRITE_REPORT {
+    publishDir "${params.outdir}", mode: 'copy'
+
+    output:
+    path "report.html"
+
+    script:
+    """
+    cat > report.html << EOF
+<html>
+<body>
+<h1>Test Report</h1>
+<p>Instance: ${params.message}</p>
+</body>
+</html>
+EOF
+    """
+}
+
+workflow {
+    WRITE_OUTPUT()
+    WRITE_REPORT()
+}

--- a/tests/test-data/workflows/glacier/outdir@main/nextflow_schema.json
+++ b/tests/test-data/workflows/glacier/outdir@main/nextflow_schema.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "type": "object",
+  "title": "with-outdir test workflow",
+  "description": "Simple workflow with outdir parameter for testing output isolation.",
+  "properties": {
+    "outdir": {
+      "type": "string",
+      "default": "results",
+      "format": "directory-path",
+      "title": "Output directory",
+      "description": "The output directory for workflow results."
+    },
+    "message": {
+      "type": "string",
+      "default": "hello",
+      "title": "Message",
+      "description": "A message to include in the output."
+    }
+  }
+}

--- a/tests/unit/frontend/HtmlReports.test.tsx
+++ b/tests/unit/frontend/HtmlReports.test.tsx
@@ -5,22 +5,28 @@ import HtmlReports from '../../../src/renderer/pages/Monitor/HtmlReports';
 
 const mockInstance = { id: 'test-instance' };
 
-const { mockGetInstanceReportsList } = vi.hoisted(() => ({
+const { mockGetInstanceReportsList, mockGetOutputPathForInstance } = vi.hoisted(() => ({
   mockGetInstanceReportsList: vi.fn().mockResolvedValue({
     ok: true,
     data: [{ id: 'r1', name: 'Report 1', path: '/reports/r1.html' }]
+  }),
+  mockGetOutputPathForInstance: vi.fn().mockResolvedValue({
+    ok: true,
+    data: null
   })
 }));
 
 vi.mock('../../../src/renderer/services/api.js', () => ({
   API: {
-    getInstanceReportsList: mockGetInstanceReportsList
+    getInstanceReportsList: mockGetInstanceReportsList,
+    getOutputPathForInstance: mockGetOutputPathForInstance
   }
 }));
 
 describe('HtmlReports', () => {
   beforeEach(() => {
     mockGetInstanceReportsList.mockClear();
+    mockGetOutputPathForInstance.mockClear();
   });
 
   it('renders report list after fetch', async () => {


### PR DESCRIPTION
- Add autoOutdir setting (checkbox) with configurable output path
- Add storeDirPath setting (checkbox) with configurable store_dir path
- Pre-fill outdir/store_dir in glacier-params.json on instance creation
- Reports tab: source dropdown (Instance/Output) when output directory exists
- Wipe dialog: 'Also delete output files' checkbox, disabled when no output dir
- Settings: new Library tab, restructured General/Advanced tabs
- Performance: React.memo on InstanceAccordion, useCallback on event handlers
- Performance: remove derived rows state, compute from instancesList directly
- Performance: useCallback on refreshInstancesList in Main.tsx
- E2e tests: outdir workflow with file verification (autoOutdir ON/OFF)
- Test data: outdir workflow with publishDir for output validation
- i18n: all new keys in en and fr

Resolves #143 