### PR TITLE
feat: custom Nextflow config (user.config) via Advanced settings

### DIFF
--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -291,6 +291,8 @@
     "output-folder": "Output folder",
     "store-dir-folder": "Store dir folder",
     "resource-limits-desc": "Process resource limits (0 = no limit)",
+    "custom-nextflow-config": "Custom Nextflow config",
+    "custom-nextflow-config-desc": "Additional Nextflow config (applied via -c)",
     "resource-limits-cpu": "Max CPUs",
     "resource-limits-memory": "Max memory",
     "nextflow-syntax-parser": "Nextflow syntax parser",

--- a/src/locales/fr/translation.json
+++ b/src/locales/fr/translation.json
@@ -277,6 +277,8 @@
     "output-folder": "Dossier de sortie",
     "store-dir-folder": "Dossier store_dir",
     "resource-limits-desc": "Limites de ressources (0 = aucune limite)",
+    "custom-nextflow-config": "Configuration Nextflow personnalisée",
+    "custom-nextflow-config-desc": "Configuration Nextflow supplémentaire (appliquée via -c)",
     "resource-limits-cpu": "CPU max",
     "resource-limits-memory": "Mémoire max",
     "nextflow-syntax-parser": "Analyseur syntaxique Nextflow",

--- a/src/main/store.ts
+++ b/src/main/store.ts
@@ -23,6 +23,7 @@ export interface StoreSchema {
   storeDirPath: string;
   resourceLimitsCpu: number;
   resourceLimitsMemory: number;
+  customNextflowConfig: string;
 }
 
 let _instance: any = null;
@@ -51,7 +52,8 @@ function getInstance() {
           outputPath: { type: 'string', default: '' },
           storeDirPath: { type: 'string', default: '' },
           resourceLimitsCpu: { type: 'number', default: 0 },
-          resourceLimitsMemory: { type: 'number', default: 0 }
+          resourceLimitsMemory: { type: 'number', default: 0 },
+          customNextflowConfig: { type: 'string', default: '' }
         },
         name: 'config',
         projectName: 'GLACIER',

--- a/src/renderer/pages/Main.tsx
+++ b/src/renderer/pages/Main.tsx
@@ -62,6 +62,7 @@ export default function MainPage({ darkMode, setDarkMode }) {
   const [storeDirPath, setStoreDirPath] = useState('');
   const [resourceLimitsCpu, setResourceLimitsCpu] = useState(0);
   const [resourceLimitsMemory, setResourceLimitsMemory] = useState(0);
+  const [customNextflowConfig, setCustomNextflowConfig] = useState('');
   const [open, setOpen] = useState(false);
   const [item, setItem] = useState('');
   const [navigateToSettingsPage, setNavigateToSettingsPage] = useState('');
@@ -120,6 +121,9 @@ export default function MainPage({ darkMode, setDarkMode }) {
       });
       API.settingsGet(SettingsKey.ResourceLimitsMemory).then((result) => {
         if (result.ok) setResourceLimitsMemory(result.data);
+      });
+      API.settingsGet(SettingsKey.CustomNextflowConfig).then((result) => {
+        if (result.ok) setCustomNextflowConfig(result.data);
       });
       const r = await API.init();
       if (!r.ok) {
@@ -369,6 +373,8 @@ export default function MainPage({ darkMode, setDarkMode }) {
                 setResourceLimitsCpu={setResourceLimitsCpu}
                 resourceLimitsMemory={resourceLimitsMemory}
                 setResourceLimitsMemory={setResourceLimitsMemory}
+                customNextflowConfig={customNextflowConfig}
+                setCustomNextflowConfig={setCustomNextflowConfig}
                 navigateToPage={navigateToSettingsPage}
                 setNavigateToPage={setNavigateToSettingsPage}
                 onReopenSetup={() => {

--- a/src/renderer/pages/Settings/Settings.tsx
+++ b/src/renderer/pages/Settings/Settings.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useRef } from 'react';
 import {
   Box,
   Typography,
@@ -51,6 +51,8 @@ export default function SettingsPage({
   setResourceLimitsCpu,
   resourceLimitsMemory,
   setResourceLimitsMemory,
+  customNextflowConfig,
+  setCustomNextflowConfig,
   navigateToPage,
   setNavigateToPage,
   onReopenSetup
@@ -60,6 +62,14 @@ export default function SettingsPage({
   const [language, setLanguage] = React.useState(i18n.language?.split('-')[0] || 'en');
   const [tabValue, setTabValue] = React.useState(0);
   const [disableSchemaValidation, setDisableSchemaValidation] = React.useState(false);
+  const configRef = useRef(customNextflowConfig);
+  const cpuRef = useRef(resourceLimitsCpu);
+  const memRef = useRef(resourceLimitsMemory);
+
+  const configInputProps = React.useMemo(
+    () => ({ input: { sx: { fontFamily: 'monospace', fontSize: '0.85rem' } } }),
+    [],
+  );
 
   const handleLanguageChange = (e) => {
     const newLang = e.target.value;
@@ -153,6 +163,13 @@ export default function SettingsPage({
     });
   };
 
+  const handleCustomNextflowConfig = (value) => {
+    setCustomNextflowConfig(value);
+    API.settingsSet(SettingsKey.CustomNextflowConfig, value).then((result) => {
+      if (!result.ok) console.error(result.error.message);
+    });
+  };
+
   const handleNextflowSyntaxParser = (value) => {
     setNextflowSyntaxParser(value);
     API.settingsSet(SettingsKey.NextflowSyntaxParser, value).then((result) => {
@@ -197,9 +214,7 @@ export default function SettingsPage({
         {...other}
       >
         {value === index && (
-          <Box sx={{ p: 3, width: '100%' }}>
-            <Typography>{children}</Typography>
-          </Box>
+          <Box sx={{ p: 3, width: '100%' }}>{children}</Box>
         )}
       </Box>
     );
@@ -423,8 +438,9 @@ export default function SettingsPage({
             <TextField
               label={t('settings.resource-limits-cpu')}
               type="number"
-              value={resourceLimitsCpu}
-              onChange={(e) => handleResourceLimitsCpu(parseInt(e.target.value) || 0)}
+              defaultValue={resourceLimitsCpu}
+              onChange={(e) => { cpuRef.current = parseInt(e.target.value) || 0; }}
+              onBlur={() => handleResourceLimitsCpu(cpuRef.current)}
               size="small"
               slotProps={{ htmlInput: { min: 0 } }}
               sx={{ width: 120 }}
@@ -432,8 +448,9 @@ export default function SettingsPage({
             <TextField
               label={t('settings.resource-limits-memory')}
               type="number"
-              value={resourceLimitsMemory}
-              onChange={(e) => handleResourceLimitsMemory(parseInt(e.target.value) || 0)}
+              defaultValue={resourceLimitsMemory}
+              onChange={(e) => { memRef.current = parseInt(e.target.value) || 0; }}
+              onBlur={() => handleResourceLimitsMemory(memRef.current)}
               size="small"
               slotProps={{
                 htmlInput: { min: 0 },
@@ -442,6 +459,20 @@ export default function SettingsPage({
               sx={{ width: 140 }}
             />
           </Box>
+          <Typography variant="body2" sx={{ mt: 2, mb: 1, color: 'text.secondary' }}>
+            {t('settings.custom-nextflow-config-desc')}
+          </Typography>
+          <TextField
+            label={t('settings.custom-nextflow-config')}
+            defaultValue={customNextflowConfig}
+            onChange={(e) => { configRef.current = e.target.value; }}
+            onBlur={() => handleCustomNextflowConfig(configRef.current)}
+            multiline
+            rows={6}
+            size="small"
+            sx={{ width: '100%' }}
+            slotProps={configInputProps}
+          />
         </Stack>
       </TabPanel>
 

--- a/src/runners/nextflow/nextflow.ts
+++ b/src/runners/nextflow/nextflow.ts
@@ -135,6 +135,12 @@ export async function runWorkflow(
     await fs.writeFile(path.resolve(instancePath, 'nextflow.config'), lines.join('\n'), 'utf8');
   }
 
+  // Write custom user config if provided
+  const customConfig = settings.get('customNextflowConfig');
+  if (customConfig) {
+    await fs.writeFile(path.resolve(instancePath, 'user.config'), customConfig, 'utf8');
+  }
+
   // Clear logs and set to append
   if (!fs_sync.existsSync(instancePath)) {
     fs_sync.mkdirSync(instancePath, { recursive: true });
@@ -226,6 +232,9 @@ export async function runWorkflow(
   ];
   if (resume) {
     cmd.push('-resume');
+  }
+  if (customConfig) {
+    cmd.push('-c', 'user.config');
   }
 
   const java_flags = [

--- a/src/runners/nextflow/nf-parse.ts
+++ b/src/runners/nextflow/nf-parse.ts
@@ -29,6 +29,7 @@ const RES = [
   { t: 'completed' as const, re: /Task completed > .*?name:\s*([^;]+);\s*status:\s*([A-Z]+);/ },
   { t: 'error' as const, re: /Error executing process > '([^']+)'/ },
   { t: 'aborted' as const, re: /Session aborted -- Cause:\s*(.+)/ },
+  { t: 'config_error' as const, re: /ERROR.*Config parsing failed/ },
   { t: 'wf_done' as const, re: /Workflow completed/ }
 ];
 
@@ -222,6 +223,9 @@ export async function readNextflowLog(path: string) {
         }
         case 'aborted':
           progress['workflow'].push({ time: ts, status: WorkflowStatus.Failed, cause: m[1] });
+          break;
+        case 'config_error':
+          progress['workflow'].push({ time: ts, status: WorkflowStatus.Failed, cause: 'Config parsing failed' });
           break;
         case 'wf_done':
           progress['workflow'].push({ time: ts, status: WorkflowStatus.Completed });

--- a/src/types/settings.ts
+++ b/src/types/settings.ts
@@ -17,7 +17,8 @@ export const SettingsKey = {
   OutputPath: 'outputPath',
   StoreDirPath: 'storeDirPath',
   ResourceLimitsCpu: 'resourceLimitsCpu',
-  ResourceLimitsMemory: 'resourceLimitsMemory'
+  ResourceLimitsMemory: 'resourceLimitsMemory',
+  CustomNextflowConfig: 'customNextflowConfig'
 } as const;
 
 export type SettingsKey = (typeof SettingsKey)[keyof typeof SettingsKey];

--- a/tests/unit/nextflow.test.js
+++ b/tests/unit/nextflow.test.js
@@ -571,5 +571,52 @@ describe('nextflow', () => {
       );
       expect(calls.length).toBe(0);
     });
+
+    it('writes user.config when customNextflowConfig is set', async () => {
+      mockSettings.get.mockImplementation((key) => {
+        if (key === 'customNextflowConfig') return 'trace { enabled = true }';
+        return 0;
+      });
+      const writeSpy = vi.spyOn(fs.promises, 'writeFile').mockResolvedValue(undefined);
+
+      await runWorkflow(makeInstance(), {});
+
+      const calls = writeSpy.mock.calls.filter(
+        ([p]) => typeof p === 'string' && p.endsWith('user.config'),
+      );
+      expect(calls.length).toBe(1);
+      expect(calls[0][1]).toContain('trace { enabled = true }');
+    });
+
+    it('appends -c user.config to spawn args when config is set', async () => {
+      mockSettings.get.mockImplementation((key) => {
+        if (key === 'customNextflowConfig') return 'some config';
+        return 0;
+      });
+      vi.spyOn(fs.promises, 'writeFile').mockResolvedValue(undefined);
+
+      await runWorkflow(makeInstance(), {});
+
+      expect(mockSpawn).toHaveBeenCalledWith(
+        'nextflow',
+        expect.arrayContaining(['-c', 'user.config']),
+        expect.anything(),
+      );
+    });
+
+    it('does not write user.config when config is empty', async () => {
+      mockSettings.get.mockImplementation((key) => {
+        if (key === 'customNextflowConfig') return '';
+        return 0;
+      });
+      const writeSpy = vi.spyOn(fs.promises, 'writeFile').mockResolvedValue(undefined);
+
+      await runWorkflow(makeInstance(), {});
+
+      const calls = writeSpy.mock.calls.filter(
+        ([p]) => typeof p === 'string' && p.endsWith('user.config'),
+      );
+      expect(calls.length).toBe(0);
+    });
   });
 });


### PR DESCRIPTION
- Add customNextflowConfig string setting persisted via electron-store
- Multiline textarea in Advanced tab (uncontrolled, saves on blur)
- Writes user.config and appends -c user.config to spawn args
- nf-parse: detect 'Config parsing failed' as workflow failure
- 3 unit tests for file write, spawn args, and empty config
- i18n keys in en and fr

Resolves #257 