### PR TITLE
feat: catalogue default parameters per workflow

### DIFF
--- a/docs/catalogues.md
+++ b/docs/catalogues.md
@@ -69,3 +69,39 @@ You can add your own workflow repositories outside of any curated catalogue:
 ## Removing a catalogue
 
 Use the **⋮** menu on the catalogue card and select **Remove catalogue**. This deletes the cloned catalogue repository from disk — it does not affect any installed workflows.
+
+## Default parameters
+
+Each workflow entry in a catalogue can include a `parameters` object that provides default values for the Parameters form. When you create an instance from a catalogue entry that has default parameters, those values are pre-filled automatically.
+
+Example `catalogue.json`:
+
+```json
+{
+  "name": "My Catalog",
+  "sections": [
+    {
+      "name": "Genomics",
+      "workflows": [
+        {
+          "name": "amplicon-nf",
+          "repo": "artic-network/amplicon-nf",
+          "version": "main",
+          "parameters": {
+            "outdir": "./results",
+            "primer_set": "SARS-CoV-2/V1200"
+          }
+        }
+      ]
+    }
+  ]
+}
+```
+
+The precedence for parameter values (highest to lowest) is:
+
+1. **User settings** — Auto-resolved values like `outdir` and `store_dir` from GLACIER settings
+2. **Catalogue defaults** — The `parameters` object in the catalogue entry
+3. **Schema defaults** — Defaults defined in the workflow's `nextflow_schema.json`
+
+This means catalogue defaults are a convenient starting point, and they can be overridden by GLACIER's auto-resolution settings or by direct changes in the Parameters form.

--- a/src/main/collection.ts
+++ b/src/main/collection.ts
@@ -73,6 +73,7 @@ export interface CatalogueWorkflow {
   repo: string;
   version?: string;
   hidden?: boolean;
+  parameters?: Record<string, any>;
 }
 
 export enum IWorkflowType {
@@ -1005,10 +1006,37 @@ export class Collection {
     const instance_path = path.join(this.instances_path, owner, repo_and_version, instance_name);
     this.ensurePathExists(instance_path);
 
-    // Auto-set store_dir and outdir if enabled
+    // Apply catalogue default parameters if specified
+    let catalogueParams: Record<string, any> = {};
+    for (const cat of this.catalogues) {
+      for (const section of cat.sections) {
+        const wf = section.workflows.find((w: any) => w.repo === workflow_id);
+        if (wf?.parameters) {
+          catalogueParams = { ...wf.parameters };
+          break;
+        }
+      }
+      if (Object.keys(catalogueParams).length > 0) break;
+    }
+    if (Object.keys(catalogueParams).length > 0) {
+      const paramsFile = path.join(instance_path, 'glacier-params.json');
+      safeFs.writeFileSync(paramsFile, JSON.stringify(catalogueParams, null, 2));
+    }
+
+    // Auto-set store_dir and outdir if enabled (overlay on catalogue defaults)
     if (this.settingsGet('autoStoreDir') || this.settingsGet('autoOutdir')) {
       const schema = await getWorkflowSchema(workflow_version.path);
-      const params: Record<string, string> = {};
+      const paramsFile = path.join(instance_path, 'glacier-params.json');
+      let existingParams: Record<string, any> = {};
+      if (safeFs.existsSync(paramsFile)) {
+        const readResult = safeFs.readFileSync(paramsFile);
+        if (readResult.ok && readResult.data) {
+          try {
+            existingParams = JSON.parse(readResult.data);
+          } catch {}
+        }
+      }
+      const params: Record<string, string> = { ...existingParams };
       if (this.settingsGet('autoStoreDir')) {
         const storeDirKey = findStoreDirKey(schema);
         if (storeDirKey) {
@@ -1026,7 +1054,6 @@ export class Collection {
         }
       }
       if (Object.keys(params).length > 0) {
-        const paramsFile = path.join(instance_path, 'glacier-params.json');
         safeFs.writeFileSync(paramsFile, JSON.stringify(params, null, 2));
       }
     }

--- a/tests/unit/collection.test.js
+++ b/tests/unit/collection.test.js
@@ -36,6 +36,7 @@ vi.mock('../../src/main/paths.js', () => ({
   getConfigPath: vi.fn(),
   getDocumentsPath: vi.fn(() => '/tmp/documents/GLACIER'),
   getCollectionsPath: vi.fn(),
+  getOutputPath: vi.fn(() => '/tmp/output/GLACIER'),
   locateReports: vi.fn(() => [])
 }));
 
@@ -231,6 +232,80 @@ describe('Collection', () => {
       await expect(collection.createWorkflowInstance('owner/repo', 'v1.0')).rejects.toThrow(
         'no versions'
       );
+    });
+
+    it('writes catalogue default parameters to glacier-params.json', async () => {
+      collection.catalogues = [
+        {
+          name: 'Test Catalogue',
+          source: 'local',
+          sections: [
+            {
+              name: 'My Workflows',
+              workflows: [
+                {
+                  name: 'my-workflow',
+                  repo: 'owner/repo',
+                  version: 'v1.0',
+                  parameters: { outdir: './results', max_cpus: 4 }
+                }
+              ]
+            }
+          ]
+        }
+      ];
+      collection.workflows = [makeWorkflow()];
+      vi.mocked(repo.generateUniqueName).mockReturnValue('happy-fox');
+      vi.mocked(repo.getWorkflowSchema).mockResolvedValue({});
+
+      const instance = await collection.createWorkflowInstance('owner/repo', 'v1.0');
+
+      const paramsFile = path.join(instance.path, 'glacier-params.json');
+      expect(fs.existsSync(paramsFile)).toBe(true);
+      const params = JSON.parse(fs.readFileSync(paramsFile, 'utf8'));
+      expect(params.outdir).toBe('./results');
+      expect(params.max_cpus).toBe(4);
+    });
+
+    it('auto-resolved settings overlay catalogue default parameters', async () => {
+      collection.catalogues = [
+        {
+          name: 'Test Catalogue',
+          source: 'local',
+          sections: [
+            {
+              name: 'My Workflows',
+              workflows: [
+                {
+                  name: 'my-workflow',
+                  repo: 'owner/repo',
+                  version: 'v1.0',
+                  parameters: { outdir: './results', max_cpus: 4 }
+                }
+              ]
+            }
+          ]
+        }
+      ];
+      collection.workflows = [makeWorkflow()];
+      vi.mocked(repo.generateUniqueName).mockReturnValue('happy-fox');
+
+      // Enable auto-resolve and provide a schema with outdir
+      collection.settingsSet('autoOutdir', true);
+      vi.mocked(repo.getWorkflowSchema).mockResolvedValue({
+        properties: { outdir: { type: 'string', format: 'directory-path' } }
+      });
+
+      const instance = await collection.createWorkflowInstance('owner/repo', 'v1.0');
+
+      const paramsFile = path.join(instance.path, 'glacier-params.json');
+      expect(fs.existsSync(paramsFile)).toBe(true);
+      const params = JSON.parse(fs.readFileSync(paramsFile, 'utf8'));
+      // Catalogue default max_cpus should be preserved
+      expect(params.max_cpus).toBe(4);
+      // outdir should be overridden by the auto-resolved output path
+      expect(params.outdir).not.toBe('./results');
+      expect(params.outdir).toContain('output');
     });
   });
 


### PR DESCRIPTION
- Add optional parameters object to CatalogueWorkflow interface
- On instance creation, scan catalogues for default params and write them to glacier-params.json
- Auto-resolved settings (store_dir, outdir) overlay on top of catalogue defaults
- Document in docs/catalogues.md with precedence rules
- 2 unit tests verifying file write and overlay behavior

Resolves #152 