### PR TITLE
feat: resource requirements check via glacier.json

### DIFF
--- a/api-server/index.js
+++ b/api-server/index.js
@@ -434,6 +434,39 @@ app.post('/api/restart-wsl', async (req, res) =>
   post_response(res, { ok: true, data: null })
 );
 
+app.post('/api/get-instance-resource-check', async (req, res) => {
+  try {
+    const workflowPath = req.body.instance?.workflow_version?.path;
+    if (!workflowPath) return post_response(res, { ok: true, data: null });
+    const { getWorkflowGlacierConfig } = await import('../dist/main/repo.js');
+    const config = await getWorkflowGlacierConfig(workflowPath);
+    const min = config?.resources?.minimum;
+    if (!min || (min.cpus === undefined && min.memory === undefined)) {
+      return post_response(res, { ok: true, data: null });
+    }
+
+    let effectiveCpu = Infinity;
+    let effectiveMem = Infinity;
+    let cpuSource = 'System';
+    let memSource = 'System';
+
+    const sysCpu = os.cpus().length;
+    const sysMem = Math.floor(os.totalmem() / (1024 * 1024 * 1024));
+    if (sysCpu < effectiveCpu) { effectiveCpu = sysCpu; cpuSource = 'System hardware'; }
+    if (sysMem < effectiveMem) { effectiveMem = sysMem; memSource = 'System hardware'; }
+
+    if ((min.cpus && effectiveCpu < min.cpus) || (min.memory && effectiveMem < min.memory)) {
+      return post_response(res, {
+        ok: true,
+        data: { minimumCpu: min.cpus, minimumMem: min.memory, effectiveCpu, effectiveMem, cpuSource, memSource }
+      });
+    }
+    return post_response(res, { ok: true, data: null });
+  } catch {
+    return post_response(res, { ok: true, data: null });
+  }
+});
+
 app.post('/api/get-default-paths', async (req, res) =>
   post_response(res, call(collection.getDefaultPaths.bind(collection)))
 );

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -33,6 +33,23 @@ The **Profiles** dropdown lists profiles extracted from `nextflow.config`. These
 
 If a `test` profile exists, a **Test launch** button appears alongside **Launch**. Use this to run the workflow with the `test` profile combined with your other selections.
 
+## Resource requirements
+
+Workflow repositories can include a `glacier.json` file at the root to specify minimum CPU and memory requirements:
+
+```json
+{
+  "resources": {
+    "minimum": {
+      "cpus": 4,
+      "memory": 8
+    }
+  }
+}
+```
+
+When you open the Parameters page for a workflow that has a `glacier.json`, GLACIER checks your system against the minimums. A warning banner appears if your effective resources (accounting for GLACIER resource limits, WSL config on Windows, and system hardware) are below the workflow's recommendations. You can still launch the workflow despite the warning.
+
 ## Launching a workflow
 
 When you click **Launch**, GLACIER:

--- a/src/main/ipc-handlers.ts
+++ b/src/main/ipc-handlers.ts
@@ -5,6 +5,7 @@ import os from 'os';
 import { execSync } from 'child_process';
 import { Collection } from './collection.js';
 import { settings, StoreSchema } from './settings.js';
+import { getWorkflowGlacierConfig } from './repo.js';
 import { Result } from '../types/types.js';
 
 const collection = Collection.getInstance();
@@ -254,6 +255,82 @@ export function registerIpcHandlers(resourceRoot?: string) {
       return { ok: true, data: null };
     } catch (err: any) {
       return { ok: false, error: { message: `Failed to restart WSL: ${err.message}` } };
+    }
+  });
+
+  ipcMain.handle('get-instance-resource-check', async (event, instance: any) => {
+    try {
+      const workflowPath = instance?.workflow_version?.path;
+      if (!workflowPath) return { ok: true, data: null };
+      const config = await getWorkflowGlacierConfig(workflowPath);
+      const min = config?.resources?.minimum;
+      if (!min || (min.cpus === undefined && min.memory === undefined)) {
+        return { ok: true, data: null };
+      }
+
+      // Gather effective limits (lowest of all layers)
+      let effectiveCpu = Infinity;
+      let effectiveMem = Infinity;
+      let cpuSource = 'System';
+      let memSource = 'System';
+
+      // Layer 1: GLACIER settings
+      const glCpu = settings.get('resourceLimitsCpu') || 0;
+      const glMem = settings.get('resourceLimitsMemory') || 0;
+      if (glCpu > 0) {
+        effectiveCpu = glCpu;
+        cpuSource = 'GLACIER settings';
+      }
+      if (glMem > 0) {
+        effectiveMem = glMem;
+        memSource = 'GLACIER settings';
+      }
+
+      // Layer 2: WSL config (Windows only)
+      const wslPath = path.join(os.homedir(), '.wslconfig');
+      if (process.platform === 'win32' && fs.existsSync(wslPath)) {
+        const wslContent = fs.readFileSync(wslPath, 'utf8');
+        const wslCpu = wslContent.match(/processors\s*=\s*(\d+)/);
+        const wslMem = wslContent.match(/memory\s*=\s*(\d+)/);
+        if (wslCpu && parseInt(wslCpu[1]) < effectiveCpu) {
+          effectiveCpu = parseInt(wslCpu[1]);
+          cpuSource = 'WSL config';
+        }
+        if (wslMem && parseInt(wslMem[1]) < effectiveMem) {
+          effectiveMem = parseInt(wslMem[1]);
+          memSource = 'WSL config';
+        }
+      }
+
+      // Layer 3: System hardware
+      const sysCpu = os.cpus().length;
+      const sysMem = Math.floor(os.totalmem() / (1024 * 1024 * 1024));
+      if (sysCpu < effectiveCpu) {
+        effectiveCpu = sysCpu;
+        cpuSource = 'System hardware';
+      }
+      if (sysMem < effectiveMem) {
+        effectiveMem = sysMem;
+        memSource = 'System hardware';
+      }
+
+      // Compare against minimums
+      if ((min.cpus && effectiveCpu < min.cpus) || (min.memory && effectiveMem < min.memory)) {
+        return {
+          ok: true,
+          data: {
+            minimumCpu: min.cpus,
+            minimumMem: min.memory,
+            effectiveCpu,
+            effectiveMem,
+            cpuSource: effectiveCpu >= sysCpu ? cpuSource : 'System hardware',
+            memSource: effectiveMem >= sysMem ? memSource : 'System hardware'
+          }
+        };
+      }
+      return { ok: true, data: null };
+    } catch {
+      return { ok: true, data: null };
     }
   });
 

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -58,6 +58,8 @@ contextBridge.exposeInMainWorld('electronAPI', {
   setOutputPath: (path: string) => ipcRenderer.invoke('set-output-path', path),
   getStoreDirPath: () => ipcRenderer.invoke('get-store-dir-path'),
   setStoreDirPath: (path: string) => ipcRenderer.invoke('set-store-dir-path', path),
+  getInstanceResourceCheck: (instance: any) =>
+    ipcRenderer.invoke('get-instance-resource-check', instance),
   checkWslConfig: () => ipcRenderer.invoke('check-wsl-config'),
   writeWslconfig: (cpu: number, mem: number) => ipcRenderer.invoke('write-wslconfig', cpu, mem),
   restartWsl: () => ipcRenderer.invoke('restart-wsl'),

--- a/src/main/repo.ts
+++ b/src/main/repo.ts
@@ -238,6 +238,17 @@ export async function getWorkflowSchema(repoPath: string) {
   }
 }
 
+export async function getWorkflowGlacierConfig(repoPath: string): Promise<any | null> {
+  const configPath = path.join(repoPath, 'glacier.json');
+  try {
+    if (!fs.existsSync(configPath)) return null;
+    const content = fs.readFileSync(configPath, 'utf8');
+    return JSON.parse(content);
+  } catch {
+    return null;
+  }
+}
+
 export async function isValidWorkflowRepo(repoPath: string) {
   const nextflowSchemaPath = path.join(repoPath, 'nextflow_schema.json');
   const dockerfilePath = path.join(repoPath, 'Dockerfile');

--- a/src/renderer/pages/Parameters/Parameters.tsx
+++ b/src/renderer/pages/Parameters/Parameters.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useMemo } from 'react';
-import { Box, Paper, Stack, Tabs, Tab, Typography, Button, Tooltip } from '@mui/material';
+import { Box, Paper, Stack, Tabs, Tab, Typography, Button, Tooltip, Alert } from '@mui/material';
 import { JsonForms } from '@jsonforms/react';
 import Ajv, { ErrorObject } from 'ajv'; // ajv is also used by jsonforms
 import addMetaSchema2020 from 'ajv/dist/refs/json-schema-2020-12/index.js';
@@ -57,6 +57,14 @@ export default function ParametersPage({
   const [readme, setReadme] = useState<string>('');
   const [license, setLicense] = useState<string>('');
   const [isValidWorkflow, setIsValidWorkflow] = useState<boolean>(true);
+  const [resourceWarning, setResourceWarning] = useState<{
+    minimumCpu?: number;
+    minimumMem?: number;
+    effectiveCpu: number;
+    effectiveMem: number;
+    cpuSource: string;
+    memSource: string;
+  } | null>(null);
 
   const paramsFilter = 'JSON';
   const paramsFileFilters = [{ name: paramsFilter, extensions: ['json'] }];
@@ -201,6 +209,10 @@ export default function ParametersPage({
       fetchLicense();
       checkValidWorkflow();
     });
+
+    API.getInstanceResourceCheck(instance).then((result) => {
+      if (result.ok) setResourceWarning(result.data);
+    });
   }, [instance]);
 
   // Read schema and compile with AJV
@@ -270,6 +282,17 @@ export default function ParametersPage({
           )}
         </Box>
       </Box>
+
+      {resourceWarning && (
+        <Alert severity="warning" sx={{ mt: 1, mb: 1 }}>
+          This workflow recommends at least
+          {resourceWarning.minimumCpu ? ` ${resourceWarning.minimumCpu} CPUs` : ''}
+          {resourceWarning.minimumCpu && resourceWarning.minimumMem ? ' and' : ''}
+          {resourceWarning.minimumMem ? ` ${resourceWarning.minimumMem} GB RAM` : ''}. Effective
+          limits: {resourceWarning.effectiveCpu} CPUs ({resourceWarning.cpuSource}) ,{' '}
+          {resourceWarning.effectiveMem} GB RAM ({resourceWarning.memSource}).
+        </Alert>
+      )}
 
       <Box sx={{ display: 'flex', alignItems: 'center' }}>
         <Tabs value={tabSelected} onChange={handleTabChange} sx={{ flex: 1 }}>

--- a/src/renderer/services/api.ts
+++ b/src/renderer/services/api.ts
@@ -25,6 +25,7 @@ const electronAPI = isElectron
         window.electronAPI.openWorkLogFile(instance, workID, logType),
       updateWorkflowInstanceStatus: (instance) =>
         window.electronAPI.updateWorkflowInstanceStatus(instance),
+      getInstanceResourceCheck: (instance) => window.electronAPI.getInstanceResourceCheck(instance),
       getInstanceReportsList: (instance) => window.electronAPI.getInstanceReportsList(instance),
       getPathReportsList: (reportsPath) => window.electronAPI.getPathReportsList(reportsPath),
       getOutputPathForInstance: (instance) => window.electronAPI.getOutputPathForInstance(instance),
@@ -169,6 +170,8 @@ const httpAPI = {
     httpDispatch('/api/open-work-log-file', 'POST', { instance, workID, logType }),
   updateWorkflowInstanceStatus: async (instance) =>
     httpDispatch('/api/update-workflow-instance-status', 'POST', { instance }),
+  getInstanceResourceCheck: async (instance) =>
+    httpDispatch('/api/get-instance-resource-check', 'POST', { instance }),
   getInstanceReportsList: async (instance) =>
     httpDispatch('/api/get-instance-reports-list', 'POST', { instance }),
   getPathReportsList: async (reportsPath) =>

--- a/tests/e2e/ui.spec.ts
+++ b/tests/e2e/ui.spec.ts
@@ -232,3 +232,38 @@ test('outdir workflow — autoOutdir ON', async ({ page }) => {
   const instancePath = path.join(docs_path, 'instances', 'glacier', 'outdir@main', instanceName);
   expect(fs.existsSync(path.join(instancePath, 'results'))).toBe(false);
 });
+
+test('resource check — high resources banner', async ({ page }) => {
+  const local_collections_path = path.resolve(path.join(__dirname, '..', 'test-data'));
+  const docs_path = path.resolve(path.join(os.tmpdir(), 'GLACIER-docs-' + Date.now().toString()));
+  fs.mkdirSync(docs_path, { recursive: true });
+
+  await page.click('#sidebar-settings-button');
+  await page.click('#settings-general-panel');
+  await page.click('#settings-reopen-setup');
+  await page.fill('#setup-config-folder', `${local_collections_path}`);
+  await page.fill('#setup-documents-folder', `${docs_path}`);
+  await page.click('#setup-continue-button');
+
+  await page.click('#sidebar-library-button');
+  await page.click('#card-high-resources');
+  await page.waitForSelector('text=This workflow recommends at least', { timeout: TIMEOUT_10s });
+});
+
+test('resource check — low resources no banner', async ({ page }) => {
+  const local_collections_path = path.resolve(path.join(__dirname, '..', 'test-data'));
+  const docs_path = path.resolve(path.join(os.tmpdir(), 'GLACIER-docs-' + Date.now().toString()));
+  fs.mkdirSync(docs_path, { recursive: true });
+
+  await page.click('#sidebar-settings-button');
+  await page.click('#settings-general-panel');
+  await page.click('#settings-reopen-setup');
+  await page.fill('#setup-config-folder', `${local_collections_path}`);
+  await page.fill('#setup-documents-folder', `${docs_path}`);
+  await page.click('#setup-continue-button');
+
+  await page.click('#sidebar-library-button');
+  await page.click('#card-low-resources');
+  await page.waitForTimeout(2000);
+  await expect(page.getByText('This workflow recommends at least')).not.toBeVisible();
+});

--- a/tests/test-data/catalogues/user_collection/store/catalogue.json
+++ b/tests/test-data/catalogues/user_collection/store/catalogue.json
@@ -29,6 +29,16 @@
           "name": "outdir",
           "repo": "glacier/outdir",
           "version": "main"
+        },
+        {
+          "name": "low-resources",
+          "repo": "glacier/low-resources",
+          "version": "main"
+        },
+        {
+          "name": "high-resources",
+          "repo": "glacier/high-resources",
+          "version": "main"
         }
       ]
     }

--- a/tests/test-data/workflows/glacier/high-resources@main/glacier.json
+++ b/tests/test-data/workflows/glacier/high-resources@main/glacier.json
@@ -1,0 +1,8 @@
+{
+  "resources": {
+    "minimum": {
+      "cpus": 999,
+      "memory": 99999
+    }
+  }
+}

--- a/tests/test-data/workflows/glacier/high-resources@main/main.nf
+++ b/tests/test-data/workflows/glacier/high-resources@main/main.nf
@@ -1,0 +1,3 @@
+#!/usr/bin/env nextflow
+nextflow.enable.dsl=2
+workflow { }

--- a/tests/test-data/workflows/glacier/high-resources@main/nextflow_schema.json
+++ b/tests/test-data/workflows/glacier/high-resources@main/nextflow_schema.json
@@ -1,0 +1,5 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "type": "object",
+  "title": "high-resources"
+}

--- a/tests/test-data/workflows/glacier/low-resources@main/glacier.json
+++ b/tests/test-data/workflows/glacier/low-resources@main/glacier.json
@@ -1,0 +1,8 @@
+{
+  "resources": {
+    "minimum": {
+      "cpus": 1,
+      "memory": 1
+    }
+  }
+}

--- a/tests/test-data/workflows/glacier/low-resources@main/main.nf
+++ b/tests/test-data/workflows/glacier/low-resources@main/main.nf
@@ -1,0 +1,3 @@
+#!/usr/bin/env nextflow
+nextflow.enable.dsl=2
+workflow { }

--- a/tests/test-data/workflows/glacier/low-resources@main/nextflow_schema.json
+++ b/tests/test-data/workflows/glacier/low-resources@main/nextflow_schema.json
@@ -1,0 +1,5 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "type": "object",
+  "title": "low-resources"
+}

--- a/tests/unit/repo.test.js
+++ b/tests/unit/repo.test.js
@@ -357,3 +357,41 @@ describe('generateUniqueName', () => {
     expect(uniqueNamesGenerator).toHaveBeenCalledTimes(2);
   });
 });
+
+describe('getWorkflowGlacierConfig', () => {
+  let configDir;
+
+  afterEach(() => {
+    if (configDir && fs.existsSync(configDir)) {
+      fs.rmSync(configDir, { recursive: true, force: true });
+    }
+  });
+
+  it('reads glacier.json and returns parsed config', async () => {
+    configDir = fs.mkdtempSync(path.join(os.tmpdir(), 'glacier-config-'));
+    fs.writeFileSync(
+      path.join(configDir, 'glacier.json'),
+      JSON.stringify({
+        resources: { minimum: { cpus: 4, memory: 8 } }
+      })
+    );
+
+    const config = await repo.getWorkflowGlacierConfig(configDir);
+    expect(config).not.toBeNull();
+    expect(config.resources.minimum.cpus).toBe(4);
+    expect(config.resources.minimum.memory).toBe(8);
+  });
+
+  it('returns null when glacier.json does not exist', async () => {
+    const config = await repo.getWorkflowGlacierConfig('/nonexistent');
+    expect(config).toBeNull();
+  });
+
+  it('returns null on malformed JSON', async () => {
+    configDir = fs.mkdtempSync(path.join(os.tmpdir(), 'glacier-config-'));
+    fs.writeFileSync(path.join(configDir, 'glacier.json'), 'not valid json');
+
+    const config = await repo.getWorkflowGlacierConfig(configDir);
+    expect(config).toBeNull();
+  });
+});


### PR DESCRIPTION
- Add getWorkflowGlacierConfig to read glacier.json from workflow repo
- IPC handler checks three resource layers: system hardware, WSL config (Windows), and GLACIER settings limits
- Yellow Alert banner on Parameters page when effective resources are below workflow minimum requirements
- API server route with same logic for web mode (e2e tests)
- Test workflows: low-resources@main (1 CPU, 1 GB) and high-resources@main (999+ CPUs, memory)
- E2e tests: verify banner appears for high-resources, absent for low
- Unit tests for getWorkflowGlacierConfig (found, missing, malformed)
- Document glacier.json format in docs/workflows.md

Resolves #100 