### PR TITLE
Strip unsupported terminal codes from log output

### DIFF
--- a/src/renderer/pages/Monitor/AnsiLog.tsx
+++ b/src/renderer/pages/Monitor/AnsiLog.tsx
@@ -11,9 +11,15 @@ const converter = new AnsiToHtml({
   stream: false
 });
 
+// Strip terminal control sequences that ansi-to-html does not render:
+// OSC (Operating System Command) sequences (e.g. OSC 8 hyperlinks) and
+// cursor-visibility codes (e.g. \x1b[?25l). SGR colour codes are kept.
+const stripUnsupportedCodes = (text: string) =>
+  text.replace(/\x1b\][^\x07\x1b]*(?:\x07|\x1b\\)/g, '').replace(/\x1b\[\?[0-9]*[hl]/g, '');
+
 export default function AnsiLog({ text }) {
   const html = useMemo(() => {
-    const raw = converter.toHtml(text || '');
+    const raw = converter.toHtml(stripUnsupportedCodes(text || ''));
     return DOMPurify.sanitize(raw);
   }, [text]);
 

--- a/tests/unit/frontend/AnsiLog.test.tsx
+++ b/tests/unit/frontend/AnsiLog.test.tsx
@@ -15,6 +15,32 @@ describe('AnsiLog', () => {
     expect(container.innerHTML).toContain('color:');
   });
 
+  it('strips OSC 8 hyperlink sequences', () => {
+    const { container } = render(
+      <AnsiLog text={'\x1b]8;;file:///tmp/work\x1b\\[a8/dbcf3f] foo\x1b]8;;\x1b\\'} />
+    );
+    expect(container.textContent).toBe('[a8/dbcf3f] foo');
+    expect(container.textContent).not.toContain(']8;;');
+  });
+
+  it('strips OSC sequences terminated by BEL', () => {
+    const { container } = render(<AnsiLog text={'\x1b]0;title\x07hello'} />);
+    expect(container.textContent).toBe('hello');
+  });
+
+  it('strips cursor-visibility codes', () => {
+    const { container } = render(<AnsiLog text={'\x1b[?25lfoo\x1b[?25h'} />);
+    expect(container.textContent).toBe('foo');
+  });
+
+  it('preserves colour codes alongside stripped OSC sequences', () => {
+    const { container } = render(
+      <AnsiLog text={'\x1b]8;;file:///tmp/work\x1b\\\x1b[1;34m[a8/dbcf3f]\x1b[0m\x1b]8;;\x1b\\'} />
+    );
+    expect(container.textContent).toBe('[a8/dbcf3f]');
+    expect(container.innerHTML).toContain('color:');
+  });
+
   it('escapes dangerous HTML (XSS)', () => {
     const { container } = render(<AnsiLog text='<img src=x onerror="alert(1)">' />);
     // ansi-to-html escapes HTML entities, so the tag is rendered as text


### PR DESCRIPTION
Remove OSC sequences (e.g. OSC 8 hyperlinks) and cursor-visibility codes before ANSI-to-HTML conversion so built-in terminal displays show clean text while preserving colour codes.

Resolves #300 