### PR TITLE
Remember execution profile on resume and default to docker

### DIFF
--- a/src/renderer/pages/Parameters/Parameters.tsx
+++ b/src/renderer/pages/Parameters/Parameters.tsx
@@ -22,6 +22,7 @@ import { renderers } from './renderers';
 import MarkdownRenderer from './MarkdownRenderer';
 import TestRunDialog from './TestRunDialog.js';
 import { SettingsKey } from '../../../types/settings.js';
+import { defaultProfileFrom } from '../../../types/profile.js';
 import { API } from '../../services/api.js';
 import { useTranslation } from 'react-i18next';
 
@@ -76,7 +77,6 @@ export default function ParametersPage({
   startOnParamsTab
 }) {
   const { t } = useTranslation();
-  const default_profile = 'standard';
 
   const [permitOverride, setPermitOverride] = useState<boolean>(false);
   const [menuAnchor, setMenuAnchor] = useState<HTMLElement | null>(null);
@@ -84,6 +84,7 @@ export default function ParametersPage({
   const [params, setParams] = useState<Record<string, unknown>>({});
   const [schema, setSchema] = useState<Record<string, unknown> | null>({});
   const [allProfiles, setAllProfiles] = useState<string[]>([]);
+  const [defaultProfile, setDefaultProfile] = useState<string>('standard');
   const [tabSelected, setTabSelected] = React.useState(startOnParamsTab ? 2 : 0);
   const [readme, setReadme] = useState<string>('');
   const [license, setLicense] = useState<string>('');
@@ -111,7 +112,7 @@ export default function ParametersPage({
     }
     // Strip out profile from params before sending to backend
     const call_params = { ...params };
-    const profile = params['profile'] || default_profile;
+    const profile = params['profile'] || defaultProfile;
     delete call_params['profile'];
     // Return PID on success
     const result = await API.runWorkflow(instance, call_params, { profile: profile });
@@ -175,10 +176,11 @@ export default function ParametersPage({
     };
     const get_available_profiles = async () => {
       const profilesResult = await API.getAvailableProfiles(instance);
-      if (!profilesResult.ok) return [default_profile];
+      if (!profilesResult.ok) return ['standard'];
       const profiles = profilesResult.data;
       setAllProfiles(profiles || []);
-      return profiles || [default_profile];
+      setDefaultProfile(defaultProfileFrom(profiles || []));
+      return profiles || ['standard'];
     };
     const get_schema = async (profiles: string[]) => {
       const schemaResult = await API.getWorkflowSchema(instance.workflow_version.path);
@@ -198,11 +200,7 @@ export default function ParametersPage({
             enum: profiles
           },
           uniqueItems: true,
-          default: profiles.includes(default_profile)
-            ? [default_profile]
-            : profiles.length > 0
-              ? [profiles[0]]
-              : []
+          default: profiles.includes(defaultProfile) ? [defaultProfile] : []
         };
       }
       setSchema(schema);

--- a/src/runners/nextflow/nextflow.ts
+++ b/src/runners/nextflow/nextflow.ts
@@ -7,6 +7,7 @@ import { promises as fs } from 'fs';
 import { IWorkflowInstance } from '../../main/collection.js';
 import { getConfigPath } from '../../main/paths.js';
 import { settings } from '../../main/settings.js';
+import { defaultProfileFrom } from '../../types/profile.js';
 import { ProcessDescriptor } from '../../types/types.js';
 
 type paramsT = { [key: string]: any };
@@ -26,6 +27,28 @@ const toPosixPath = (base: string) => {
 const resolvePath = (base: string, name: string) => {
   const rtn = toPosixPath(path.resolve(base, name));
   return rtn;
+};
+
+// Read the profile saved at launch (glacier-profile.json). Returns undefined
+// when the file is missing or unreadable so callers can fall back gracefully.
+const readStoredProfile = async (file: string): Promise<string | undefined> => {
+  try {
+    const raw = await fs.readFile(file, 'utf8');
+    const parsed = JSON.parse(raw);
+    const profile = parsed?.profile;
+    if (typeof profile === 'string' && profile) return profile;
+    if (Array.isArray(profile) && profile.length > 0) return profile.join(',');
+  } catch {
+    /* missing or corrupt profile file */
+  }
+  return undefined;
+};
+
+// Resolve the default profile for a workflow from its nextflow.config
+// (docker if defined, else standard/first available).
+const resolveDefaultProfile = async (instance: IWorkflowInstance): Promise<string> => {
+  const profiles = await getAvailableProfiles(instance);
+  return defaultProfileFrom(profiles);
 };
 
 const looksLikePath = (s: string): boolean => {
@@ -107,7 +130,7 @@ const get_electron_paths = async () => {
 export async function runWorkflow(
   instance: IWorkflowInstance,
   params: paramsT,
-  { resume = false, restart = false, profile = 'standard' }: IRunWorkflowOpts = {}
+  { resume = false, restart = false, profile }: IRunWorkflowOpts = {}
 ): Promise<ProcessDescriptor | null> {
   const { is_electron, java_binary, jar_file, env } = await get_electron_paths();
 
@@ -135,6 +158,23 @@ export async function runWorkflow(
   const paramsFile = path.resolve(instancePath, 'glacier-params.json');
   if (!resume && !restart) {
     await fs.writeFile(paramsFile, JSON.stringify(params, null, 2), 'utf8');
+  }
+
+  // Resolve the execution profile: an explicit profile wins; on resume/restart
+  // reuse the profile saved at launch; otherwise fall back to the workflow's
+  // default (docker if defined, else standard). Persist it so resume remembers it.
+  const profileFile = path.resolve(instancePath, 'glacier-profile.json');
+  let effectiveProfile = profile;
+  if (effectiveProfile === undefined) {
+    if (resume || restart) {
+      effectiveProfile = await readStoredProfile(profileFile);
+    }
+    if (effectiveProfile === undefined) {
+      effectiveProfile = await resolveDefaultProfile(instance);
+    }
+  }
+  if (!resume && !restart) {
+    await fs.writeFile(profileFile, JSON.stringify({ profile: effectiveProfile }), 'utf8');
   }
 
   // Write resource limits nextflow.config if configured
@@ -176,7 +216,7 @@ export async function runWorkflow(
       '-work-dir',
       toPosixPath(workPath),
       '-profile',
-      profile,
+      effectiveProfile,
       '-params-file',
       toPosixPath(paramsFile),
       '-name',
@@ -254,7 +294,7 @@ export async function runWorkflow(
     '-work-dir',
     toPosixPath(workPath),
     '-profile',
-    profile,
+    effectiveProfile,
     '-params-file',
     toPosixPath(paramsFile),
     '-name',

--- a/src/types/profile.ts
+++ b/src/types/profile.ts
@@ -1,0 +1,10 @@
+// Resolve the default Nextflow execution profile from the set of profiles
+// defined in a workflow's nextflow.config. GLACIER is a Docker/Nextflow
+// orchestrator, so prefer a `docker` profile when the workflow defines one;
+// otherwise fall back to Nextflow's implicit `standard` profile, then the
+// first available profile.
+export const defaultProfileFrom = (profiles: string[]): string => {
+  if (profiles.includes('docker')) return 'docker';
+  if (profiles.includes('standard')) return 'standard';
+  return profiles[0] || 'standard';
+};

--- a/tests/unit/frontend/profile.test.ts
+++ b/tests/unit/frontend/profile.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from 'vitest';
+import { defaultProfileFrom } from '../../../src/types/profile';
+
+describe('defaultProfileFrom', () => {
+  it('prefers docker when the workflow defines it', () => {
+    expect(defaultProfileFrom(['docker', 'standard'])).toBe('docker');
+  });
+
+  it('falls back to standard when docker is absent', () => {
+    expect(defaultProfileFrom(['standard', 'test'])).toBe('standard');
+  });
+
+  it('falls back to the first profile when neither docker nor standard exist', () => {
+    expect(defaultProfileFrom(['alpha', 'beta'])).toBe('alpha');
+  });
+
+  it('falls back to standard for an empty list', () => {
+    expect(defaultProfileFrom([])).toBe('standard');
+  });
+});

--- a/tests/unit/nextflow.test.js
+++ b/tests/unit/nextflow.test.js
@@ -619,4 +619,114 @@ describe('nextflow', () => {
       expect(calls.length).toBe(0);
     });
   });
+
+  describe('runWorkflow — profile persistence and recall', () => {
+    let profileRunWorkflow;
+    let origPlatformDarwin;
+    let configDir;
+
+    beforeEach(async () => {
+      origPlatformDarwin = Object.getOwnPropertyDescriptor(process, 'platform');
+      Object.defineProperty(process, 'platform', { value: 'darwin', configurable: true });
+      vi.resetModules();
+      const mod = await import('../../src/runners/nextflow/nextflow.js');
+      profileRunWorkflow = mod.runWorkflow;
+    });
+
+    afterEach(() => {
+      if (origPlatformDarwin) {
+        Object.defineProperty(process, 'platform', origPlatformDarwin);
+      }
+      if (configDir && fs.existsSync(configDir)) {
+        fs.rmSync(configDir, { recursive: true, force: true });
+      }
+    });
+
+    function instanceWithConfig(content) {
+      configDir = fs.mkdtempSync(path.join(os.tmpdir(), 'nf-profile-'));
+      fs.writeFileSync(path.join(configDir, 'nextflow.config'), content, 'utf8');
+      return makeInstance({ workflow_version: { path: configDir, version: 'v1.0' } });
+    }
+
+    it('persists the selected profile on fresh launch', async () => {
+      const writeSpy = vi.spyOn(fs.promises, 'writeFile').mockResolvedValue(undefined);
+
+      await profileRunWorkflow(makeInstance(), {}, { profile: 'conda' });
+
+      expect(writeSpy).toHaveBeenCalledWith(
+        expect.stringContaining('glacier-profile.json'),
+        JSON.stringify({ profile: 'conda' }),
+        'utf8'
+      );
+      expect(mockSpawn).toHaveBeenCalledWith(
+        'nextflow',
+        expect.arrayContaining(['-profile', 'conda']),
+        expect.anything()
+      );
+    });
+
+    it('resume recalls the profile saved at launch', async () => {
+      makeInstance();
+      fs.writeFileSync(
+        path.resolve(DEFAULT_INSTANCE_PATH, 'glacier-profile.json'),
+        JSON.stringify({ profile: 'conda' }),
+        'utf8'
+      );
+
+      await profileRunWorkflow(makeInstance(), {}, { resume: true });
+
+      expect(mockSpawn).toHaveBeenCalledWith(
+        'nextflow',
+        expect.arrayContaining(['-profile', 'conda', '-resume']),
+        expect.anything()
+      );
+    });
+
+    it('resume defaults to docker when no profile saved and workflow defines it', async () => {
+      await profileRunWorkflow(
+        instanceWithConfig(`
+          profiles {
+            docker { }
+            standard { }
+          }
+        `),
+        {},
+        { resume: true }
+      );
+
+      expect(mockSpawn).toHaveBeenCalledWith(
+        'nextflow',
+        expect.arrayContaining(['-profile', 'docker', '-resume']),
+        expect.anything()
+      );
+    });
+
+    it('resume falls back to standard when no profile saved and no docker profile', async () => {
+      await profileRunWorkflow(makeInstance(), {}, { resume: true });
+
+      expect(mockSpawn).toHaveBeenCalledWith(
+        'nextflow',
+        expect.arrayContaining(['-profile', 'standard', '-resume']),
+        expect.anything()
+      );
+    });
+
+    it('fresh launch defaults to docker when no explicit profile and workflow defines it', async () => {
+      await profileRunWorkflow(
+        instanceWithConfig(`
+          profiles {
+            docker { }
+            standard { }
+          }
+        `),
+        {}
+      );
+
+      expect(mockSpawn).toHaveBeenCalledWith(
+        'nextflow',
+        expect.arrayContaining(['-profile', 'docker']),
+        expect.anything()
+      );
+    });
+  });
 });


### PR DESCRIPTION
Resume reuses the profile saved at launch (glacier-profile.json) instead of silently falling back to 'standard'. The launch default is no longer hardcoded: prefer a 'docker' profile when the workflow defines one, else standard/first available, via a shared defaultProfileFrom helper used by both the launch form and the runner.

Closes #298 , #299 